### PR TITLE
Fix CMake 3.5 compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ if (HEXL_TREAT_WARNING_AS_ERROR)
   add_compile_options(-Werror)
 endif()
 
+set(HEXL_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})
 set(HEXL_SRC_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/hexl)
 set(HEXL_INC_ROOT_DIR ${HEXL_SRC_ROOT_DIR}/include) # Public headers
 
@@ -174,51 +175,5 @@ endif()
 if (HEXL_DOCS)
   add_subdirectory(docs)
 endif()
-
-#------------------------------------------------------------------------------
-# Config export...
-#------------------------------------------------------------------------------
-# Config filenames
-set(HEXL_TARGET_FILENAME ${CMAKE_CURRENT_BINARY_DIR}/cmake/hexl-${HEXL_VERSION}/HEXLTargets.cmake)
-set(HEXL_CONFIG_IN_FILENAME ${CMAKE_CURRENT_SOURCE_DIR}/cmake/hexl/HEXLConfig.cmake.in)
-set(HEXL_CONFIG_FILENAME ${CMAKE_CURRENT_SOURCE_DIR}/cmake/hexl-${HEXL_VERSION}/HEXLConfig.cmake)
-set(HEXL_CONFIG_VERSION_FILENAME ${CMAKE_CURRENT_BINARY_DIR}/cmake/hexl-${HEXL_VERSION}/HEXLConfigVersion.cmake)
-
-set(HEXL_CONFIG_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/hexl-${HEXL_VERSION}/)
-
-# Create and install the CMake config and target file
-install(
-    EXPORT HEXLTargets
-    NAMESPACE HEXL::
-    DESTINATION ${HEXL_CONFIG_INSTALL_DIR}
-)
-
-# Export version
-write_basic_package_version_file(
-  ${HEXL_CONFIG_VERSION_FILENAME}
-  VERSION ${HEXL_VERSION}
-  COMPATIBILITY ExactVersion)
-
-include(CMakePackageConfigHelpers)
-    configure_package_config_file(
-        ${HEXL_CONFIG_IN_FILENAME} ${HEXL_CONFIG_FILENAME}
-        INSTALL_DESTINATION ${HEXL_CONFIG_INSTALL_DIR}
-    )
-
-install(
-    TARGETS hexl
-    EXPORT HEXLTargets
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    )
-
-install(FILES ${HEXL_CONFIG_FILENAME}
-              ${HEXL_CONFIG_VERSION_FILENAME}
-        DESTINATION ${HEXL_CONFIG_INSTALL_DIR})
-
-export(EXPORT HEXLTargets
-        FILE ${HEXL_TARGET_FILENAME})
-
 
 add_custom_target(check COMMAND pre-commit install && pre-commit run --all-files)

--- a/hexl/CMakeLists.txt
+++ b/hexl/CMakeLists.txt
@@ -94,7 +94,7 @@ if (HEXL_SHARED_LIB)
 else ()
     # For static library, we include all the dependencies for Intel HEXL in
     # the libhexl.a.
-    # For proper export of IntelHEXLConfig.cmake / IntelHEXLTargts.cmake,
+    # For proper export of HEXLConfig.cmake / HEXLTargets.cmake,
     # we avoid explicitly linking dependencies via target_link_libraries, since
     # this would add dependencies to the exported hexl target.
     add_dependencies(hexl cpu_features)
@@ -163,3 +163,48 @@ else ()
 endif()
 
 install(TARGETS hexl DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+#------------------------------------------------------------------------------
+# Config export...
+#------------------------------------------------------------------------------
+
+# Config filenames
+set(HEXL_TARGET_FILENAME ${CMAKE_CURRENT_BINARY_DIR}/cmake/hexl-${HEXL_VERSION}/HEXLTargets.cmake)
+set(HEXL_CONFIG_IN_FILENAME ${HEXL_CMAKE_PATH}/HEXLConfig.cmake.in)
+set(HEXL_CONFIG_FILENAME ${HEXL_ROOT_DIR}/cmake/hexl-${HEXL_VERSION}/HEXLConfig.cmake)
+set(HEXL_CONFIG_VERSION_FILENAME ${CMAKE_CURRENT_BINARY_DIR}/cmake/hexl-${HEXL_VERSION}/HEXLConfigVersion.cmake)
+set(HEXL_CONFIG_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/hexl-${HEXL_VERSION}/)
+
+# Create and install the CMake config and target file
+install(
+    EXPORT HEXLTargets
+    NAMESPACE HEXL::
+    DESTINATION ${HEXL_CONFIG_INSTALL_DIR}
+)
+
+# Export version
+write_basic_package_version_file(
+  ${HEXL_CONFIG_VERSION_FILENAME}
+  VERSION ${HEXL_VERSION}
+  COMPATIBILITY ExactVersion)
+
+include(CMakePackageConfigHelpers)
+    configure_package_config_file(
+        ${HEXL_CONFIG_IN_FILENAME} ${HEXL_CONFIG_FILENAME}
+        INSTALL_DESTINATION ${HEXL_CONFIG_INSTALL_DIR}
+    )
+
+install(
+    TARGETS hexl
+    EXPORT HEXLTargets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+
+install(FILES ${HEXL_CONFIG_FILENAME}
+              ${HEXL_CONFIG_VERSION_FILENAME}
+        DESTINATION ${HEXL_CONFIG_INSTALL_DIR})
+
+export(EXPORT HEXLTargets
+        FILE ${HEXL_TARGET_FILENAME})


### PR DESCRIPTION
I was seeing some errors relating to install targets defined in a different directory, which may affect CMake versions after 3.5 as well.