### PR TITLE
Fboemer/fix clang 13 debug compile 2

### DIFF
--- a/benchmark/bench-ntt.cpp
+++ b/benchmark/bench-ntt.cpp
@@ -331,7 +331,7 @@ BENCHMARK(BM_InvNTT_AVX512DQ_32)
 static void BM_InvNTT_AVX512DQ_64(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
   uint64_t output_mod_factor = state.range(1);
-  size_t modulus = GeneratePrimes(1, 62, ntt_size)[0];
+  size_t modulus = GeneratePrimes(1, 61, ntt_size)[0];
 
   AlignedVector64<uint64_t> input(ntt_size, 1);
   NTT ntt(ntt_size, modulus);

--- a/hexl/include/hexl/ntt/ntt.hpp
+++ b/hexl/include/hexl/ntt/ntt.hpp
@@ -86,7 +86,7 @@ class NTT {
   /// @brief Returns true if arguments satisfy constraints for negacyclic NTT
   /// @param[in] degree Size of the transform, i.e. the polynomial degree. Must
   /// be a power of two.
-  /// @param[in] modulus Prime modulus. Must satisfy
+  /// @param[in] modulus Prime modulus. Must satisfy q mod 2N = 1
   static bool CheckArguments(uint64_t degree, uint64_t modulus);
 
   /// @brief Compute forward NTT. Results are bit-reversed.

--- a/hexl/include/hexl/ntt/ntt.hpp
+++ b/hexl/include/hexl/ntt/ntt.hpp
@@ -84,7 +84,7 @@ class NTT {
                     std::move(a), std::forward<AllocatorArgs>(args)...))) {}
 
   // Returns true if arguments satisfy constraints for negacyclic NTT
-  bool CheckArguments(uint64_t degree, uint64_t modulus);
+  static bool CheckArguments(uint64_t degree, uint64_t modulus);
 
   /// @brief Compute forward NTT. Results are bit-reversed.
   /// @param[out] result Stores the result
@@ -191,10 +191,10 @@ class NTT {
   }
 
   /// @brief Maximum power of 2 in degree
-  static const size_t s_max_degree_bits{20};
+  static size_t MaxDegreeBits() { return 20; }
 
   /// @brief Maximum number of bits in modulus;
-  static const size_t s_max_modulus_bits{62};
+  static size_t MaxModulusBits() { return 62; }
 
   /// @brief Default bit shift used in Barrett precomputation
   static const size_t s_default_shift_bits{64};

--- a/hexl/include/hexl/ntt/ntt.hpp
+++ b/hexl/include/hexl/ntt/ntt.hpp
@@ -84,9 +84,9 @@ class NTT {
                     std::move(a), std::forward<AllocatorArgs>(args)...))) {}
 
   /// @brief Returns true if arguments satisfy constraints for negacyclic NTT
-  /// @param[in] degree Size of the transform, i.e. the polynomial degree. Must
-  /// be a power of two.
-  /// @param[in] modulus Prime modulus. Must satisfy q mod 2N = 1
+  /// @param[in] degree N. Size of the transform, i.e. the polynomial degree.
+  /// Must be a power of two.
+  /// @param[in] modulus Prime modulus q. Must satisfy q mod 2N = 1
   static bool CheckArguments(uint64_t degree, uint64_t modulus);
 
   /// @brief Compute forward NTT. Results are bit-reversed.

--- a/hexl/include/hexl/ntt/ntt.hpp
+++ b/hexl/include/hexl/ntt/ntt.hpp
@@ -83,7 +83,10 @@ class NTT {
                 std::make_shared<AllocatorAdapter<Allocator, AllocatorArgs...>>(
                     std::move(a), std::forward<AllocatorArgs>(args)...))) {}
 
-  // Returns true if arguments satisfy constraints for negacyclic NTT
+  /// @brief Returns true if arguments satisfy constraints for negacyclic NTT
+  /// @param[in] degree Size of the transform, i.e. the polynomial degree. Must
+  /// be a power of two.
+  /// @param[in] modulus Prime modulus. Must satisfy
   static bool CheckArguments(uint64_t degree, uint64_t modulus);
 
   /// @brief Compute forward NTT. Results are bit-reversed.

--- a/hexl/include/hexl/ntt/ntt.hpp
+++ b/hexl/include/hexl/ntt/ntt.hpp
@@ -83,6 +83,9 @@ class NTT {
                 std::make_shared<AllocatorAdapter<Allocator, AllocatorArgs...>>(
                     std::move(a), std::forward<AllocatorArgs>(args)...))) {}
 
+  // Returns true if arguments satisfy constraints for negacyclic NTT
+  bool CheckArguments(uint64_t degree, uint64_t modulus);
+
   /// @brief Compute forward NTT. Results are bit-reversed.
   /// @param[out] result Stores the result
   /// @param[in] operand Data on which to compute the NTT

--- a/hexl/ntt/fwd-ntt-avx512.cpp
+++ b/hexl/ntt/fwd-ntt-avx512.cpp
@@ -243,7 +243,7 @@ void ForwardTransformToBitReverseAVX512(
     const uint64_t* precon_root_of_unity_powers, uint64_t input_mod_factor,
     uint64_t output_mod_factor, uint64_t recursion_depth,
     uint64_t recursion_half) {
-  HEXL_CHECK(CheckNTTArguments(n, modulus), "");
+  HEXL_CHECK(CheckArguments(n, modulus), "");
   HEXL_CHECK(modulus < MaximumValue(BitShift) / 4,
              "modulus " << modulus << " too large for BitShift " << BitShift
                         << " => maximum value " << MaximumValue(BitShift) / 4);

--- a/hexl/ntt/fwd-ntt-avx512.cpp
+++ b/hexl/ntt/fwd-ntt-avx512.cpp
@@ -243,7 +243,7 @@ void ForwardTransformToBitReverseAVX512(
     const uint64_t* precon_root_of_unity_powers, uint64_t input_mod_factor,
     uint64_t output_mod_factor, uint64_t recursion_depth,
     uint64_t recursion_half) {
-  HEXL_CHECK(CheckArguments(n, modulus), "");
+  HEXL_CHECK(NTT::CheckArguments(n, modulus), "");
   HEXL_CHECK(modulus < MaximumValue(BitShift) / 4,
              "modulus " << modulus << " too large for BitShift " << BitShift
                         << " => maximum value " << MaximumValue(BitShift) / 4);

--- a/hexl/ntt/inv-ntt-avx512.cpp
+++ b/hexl/ntt/inv-ntt-avx512.cpp
@@ -244,7 +244,7 @@ void InverseTransformFromBitReverseAVX512(
     const uint64_t* precon_inv_root_of_unity_powers, uint64_t input_mod_factor,
     uint64_t output_mod_factor, uint64_t recursion_depth,
     uint64_t recursion_half) {
-  HEXL_CHECK(CheckArguments(n, modulus), "");
+  HEXL_CHECK(NTT::CheckArguments(n, modulus), "");
   HEXL_CHECK(n >= 16,
              "InverseTransformFromBitReverseAVX512 doesn't support small "
              "transforms. Need n >= 16, got n = "

--- a/hexl/ntt/inv-ntt-avx512.cpp
+++ b/hexl/ntt/inv-ntt-avx512.cpp
@@ -244,7 +244,7 @@ void InverseTransformFromBitReverseAVX512(
     const uint64_t* precon_inv_root_of_unity_powers, uint64_t input_mod_factor,
     uint64_t output_mod_factor, uint64_t recursion_depth,
     uint64_t recursion_half) {
-  HEXL_CHECK(CheckNTTArguments(n, modulus), "");
+  HEXL_CHECK(CheckArguments(n, modulus), "");
   HEXL_CHECK(n >= 16,
              "InverseTransformFromBitReverseAVX512 doesn't support small "
              "transforms. Need n >= 16, got n = "

--- a/hexl/ntt/ntt-internal.cpp
+++ b/hexl/ntt/ntt-internal.cpp
@@ -183,8 +183,9 @@ bool NTT::CheckArguments(uint64_t degree, uint64_t modulus) {
   HEXL_CHECK(modulus <= (1ULL << NTT::MaxModulusBits()),
              "modulus should be less than 2^" << NTT::MaxModulusBits()
                                               << " got " << modulus);
-
   HEXL_CHECK(modulus % (2 * degree) == 1, "modulus mod 2n != 1");
+  HEXL_CHECK(IsPrime(modulus), "modulus is not prime");
+
   return true;
 }
 

--- a/hexl/ntt/ntt-internal.cpp
+++ b/hexl/ntt/ntt-internal.cpp
@@ -177,9 +177,12 @@ bool NTT::CheckArguments(uint64_t degree, uint64_t modulus) {
   (void)modulus;
   HEXL_CHECK(IsPowerOfTwo(degree),
              "degree " << degree << " is not a power of 2");
-  HEXL_CHECK(degree <= (1 << NTT::s_max_degree_bits),
-             "degree should be less than 2^" << NTT::s_max_degree_bits
-                                             << " got " << degree);
+  HEXL_CHECK(degree <= (1ULL << NTT::MaxDegreeBits()),
+             "degree should be less than 2^" << NTT::MaxDegreeBits() << " got "
+                                             << degree);
+  HEXL_CHECK(modulus <= (1ULL << NTT::MaxModulusBits()),
+             "modulus should be less than 2^" << NTT::MaxModulusBits()
+                                              << " got " << modulus);
 
   HEXL_CHECK(modulus % (2 * degree) == 1, "modulus mod 2n != 1");
   return true;
@@ -324,7 +327,7 @@ void ForwardTransformToBitReverse64(uint64_t* operand, uint64_t n,
                                     const uint64_t* precon_root_of_unity_powers,
                                     uint64_t input_mod_factor,
                                     uint64_t output_mod_factor) {
-  HEXL_CHECK(CheckArguments(n, modulus), "");
+  HEXL_CHECK(NTT::CheckArguments(n, modulus), "");
   HEXL_CHECK_BOUNDS(operand, n, modulus * input_mod_factor,
                     "operand exceeds bound " << modulus * input_mod_factor);
   HEXL_CHECK(root_of_unity_powers != nullptr,
@@ -393,7 +396,7 @@ void ForwardTransformToBitReverse64(uint64_t* operand, uint64_t n,
 void ReferenceForwardTransformToBitReverse(
     uint64_t* operand, uint64_t n, uint64_t modulus,
     const uint64_t* root_of_unity_powers) {
-  HEXL_CHECK(CheckArguments(n, modulus), "");
+  HEXL_CHECK(NTT::CheckArguments(n, modulus), "");
   HEXL_CHECK(root_of_unity_powers != nullptr,
              "root_of_unity_powers == nullptr");
   HEXL_CHECK(operand != nullptr, "operand == nullptr");
@@ -425,7 +428,7 @@ void InverseTransformFromBitReverse64(
     const uint64_t* inv_root_of_unity_powers,
     const uint64_t* precon_inv_root_of_unity_powers, uint64_t input_mod_factor,
     uint64_t output_mod_factor) {
-  HEXL_CHECK(CheckArguments(n, modulus), "");
+  HEXL_CHECK(NTT::CheckArguments(n, modulus), "");
   HEXL_CHECK(inv_root_of_unity_powers != nullptr,
              "inv_root_of_unity_powers == nullptr");
   HEXL_CHECK(precon_inv_root_of_unity_powers != nullptr,

--- a/hexl/ntt/ntt-internal.hpp
+++ b/hexl/ntt/ntt-internal.hpp
@@ -41,8 +41,5 @@ void InverseTransformFromBitReverse64(
     const uint64_t* precon_inv_root_of_unity_powers,
     uint64_t input_mod_factor = 1, uint64_t output_mod_factor = 1);
 
-// Returns true if arguments satisfy constraints for negacyclic NTT
-bool CheckNTTArguments(uint64_t degree, uint64_t modulus);
-
 }  // namespace hexl
 }  // namespace intel


### PR DESCRIPTION
Avoiding
```
/usr/bin/ld: ../hexl/lib/libhexl_debug.a(ntt-internal.cpp.o): in function `intel::hexl::CheckNTTArguments(unsigned long, unsigned long)':
/home/fboemer/repos/intel-hexl/hexl/ntt/ntt-internal.cpp:494: undefined reference to `intel::hexl::NTT::s_max_degree_bits'
```