### PR TITLE
Fix AVX512 InvNTT bound

### DIFF
--- a/hexl/include/hexl/ntt/ntt.hpp
+++ b/hexl/include/hexl/ntt/ntt.hpp
@@ -220,7 +220,7 @@ class NTT {
 
   /// @brief Maximum modulus to use AVX512-IFMA acceleration for the inverse
   /// transform
-  static const size_t s_max_inv_ifma_modulus{1ULL << (s_ifma_shift_bits - 1)};
+  static const size_t s_max_inv_ifma_modulus{1ULL << (s_ifma_shift_bits - 2)};
 
  private:
   void ComputeRootOfUnityPowers();

--- a/hexl/ntt/fwd-ntt-avx512.hpp
+++ b/hexl/ntt/fwd-ntt-avx512.hpp
@@ -14,7 +14,7 @@ namespace hexl {
 /// @param[in, out] operand Input data. Overwritten with NTT output
 /// @param[in] n Size of the transfrom, i.e. the polynomial degree. Must be a
 /// power of two.
-/// @param[in] modulus Prime modulus. Must satisfy q == 1 mod 2n
+/// @param[in] modulus Prime modulus. Must satisfy q == 1 mod 2n and q < 2^50.
 /// @param[in] root_of_unity_powers Powers of 2n'th root of unity in F_q. In
 /// bit-reversed order.
 /// @param[in] precon_root_of_unity_powers Pre-conditioned Powers of 2n'th root

--- a/hexl/ntt/inv-ntt-avx512.hpp
+++ b/hexl/ntt/inv-ntt-avx512.hpp
@@ -14,7 +14,7 @@ namespace hexl {
 /// @param[in, out] operand Input data. Overwritten with NTT output
 /// @param[in] n Size of the transfrom, i.e. the polynomial degree. Must be a
 /// power of two.
-/// @param[in] modulus Prime modulus. Must satisfy q == 1 mod 2n
+/// @param[in] modulus Prime modulus. Must satisfy q == 1 mod 2n and q < 2^50.
 /// @param[in] root_of_unity_powers Powers of inverse 2n'th root of unity in
 /// F_q. In bit-reversed order.
 /// @param[in] precon_root_of_unity_powers Pre-conditioned powers of inverse


### PR DESCRIPTION
Algorithm 3 and 4 of https://arxiv.org/pdf/1205.2926.pdf both have the bound `modulus < beta / 4` which is `2^52 / 4` using AVX512 IFMA.

The InvNTT implementation currently only checks for `modulus < beta \ 2`. This PR fixes the issue

