### PR TITLE
Faster EltwiseFMAModAVX512

### DIFF
--- a/benchmark/bench-eltwise-fma-mod.cpp
+++ b/benchmark/bench-eltwise-fma-mod.cpp
@@ -17,75 +17,75 @@ namespace hexl {
 
 //=================================================================
 
-// state[0] is the degree
-static void BM_EltwiseFMAModNative(benchmark::State& state) {  //  NOLINT
+static void BM_EltwiseFMAModAddNative(benchmark::State& state) {  //  NOLINT
   size_t input_size = state.range(0);
   uint64_t modulus = 0xffffffffffc0001ULL;
+  bool add = state.range(1);
 
-  AlignedVector64<uint64_t> op1(input_size, 1);
-  uint64_t op2 = 1;
-  AlignedVector64<uint64_t> op3(input_size, 2);
+  AlignedVector64<uint64_t> input1(input_size, 1);
+  uint64_t input2 = 1;
+  AlignedVector64<uint64_t> input3(input_size, 2);
+  uint64_t* arg3 = add ? input3.data() : nullptr;
 
   for (auto _ : state) {
-    EltwiseFMAMod(op1.data(), op1.data(), op2, op3.data(), op1.size(), modulus,
-                  1);
+    EltwiseFMAMod(input1.data(), input1.data(), input2, arg3, input1.size(),
+                  modulus, 1);
   }
 }
 
-BENCHMARK(BM_EltwiseFMAModNative)
+BENCHMARK(BM_EltwiseFMAModAddNative)
     ->Unit(benchmark::kMicrosecond)
-    ->Args({1024})
-    ->Args({4096})
-    ->Args({16384});
+    ->ArgsProduct({{1024, 8192, 16384}, {false, true}});
 
 //=================================================================
 
 #ifdef HEXL_HAS_AVX512DQ
-// state[0] is the degree
 static void BM_EltwiseFMAModAVX512DQ(benchmark::State& state) {  //  NOLINT
   size_t input_size = state.range(0);
   size_t modulus = 100;
+  bool add = state.range(1);
 
   AlignedVector64<uint64_t> input1(input_size, 1);
   uint64_t input2 = 3;
   AlignedVector64<uint64_t> input3(input_size, 2);
 
+  uint64_t* arg3 = add ? input3.data() : nullptr;
+
   for (auto _ : state) {
-    EltwiseFMAModAVX512<64, 1>(input1.data(), input1.data(), input2,
-                               input3.data(), input_size, modulus);
+    EltwiseFMAModAVX512<64, 1>(input1.data(), input1.data(), input2, arg3,
+                               input_size, modulus);
   }
 }
 
 BENCHMARK(BM_EltwiseFMAModAVX512DQ)
     ->Unit(benchmark::kMicrosecond)
-    ->Args({1024})
-    ->Args({4096})
-    ->Args({16384});
+    ->ArgsProduct({{1024, 8192, 16384}, {false, true}});
 #endif
 
 //=================================================================
 
 #ifdef HEXL_HAS_AVX512IFMA
-// state[0] is the degree
 static void BM_EltwiseFMAModAVX512IFMA(benchmark::State& state) {  //  NOLINT
   size_t input_size = state.range(0);
   size_t modulus = 100;
+  bool add = state.range(1);
 
   AlignedVector64<uint64_t> input1(input_size, 1);
   uint64_t input2 = 3;
   AlignedVector64<uint64_t> input3(input_size, 2);
 
+  uint64_t* arg3 = add ? input3.data() : nullptr;
+
   for (auto _ : state) {
-    EltwiseFMAModAVX512<52, 1>(input1.data(), input1.data(), input2,
-                               input3.data(), input_size, modulus);
+    EltwiseFMAModAVX512<52, 1>(input1.data(), input1.data(), input2, arg3,
+                               input_size, modulus);
   }
 }
 
 BENCHMARK(BM_EltwiseFMAModAVX512IFMA)
     ->Unit(benchmark::kMicrosecond)
-    ->Args({1024})
-    ->Args({4096})
-    ->Args({16384});
+    ->ArgsProduct({{1024, 8192, 16384}, {false, true}});
+
 #endif
 
 }  // namespace hexl

--- a/benchmark/bench-ntt.cpp
+++ b/benchmark/bench-ntt.cpp
@@ -196,7 +196,7 @@ BENCHMARK(BM_FwdNTTInPlace)
 // state[0] is the degree
 static void BM_FwdNTTCopy(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
-  size_t modulus = GeneratePrimes(1, 61, ntt_size)[0];
+  size_t modulus = GeneratePrimes(1, 45, ntt_size)[0];
 
   AlignedVector64<uint64_t> input(ntt_size, 1);
   AlignedVector64<uint64_t> output(ntt_size, 1);
@@ -208,6 +208,26 @@ static void BM_FwdNTTCopy(benchmark::State& state) {  //  NOLINT
 }
 
 BENCHMARK(BM_FwdNTTCopy)
+    ->Unit(benchmark::kMicrosecond)
+    ->Args({1024})
+    ->Args({4096})
+    ->Args({16384});
+
+// state[0] is the degree
+static void BM_InvNTTCopy(benchmark::State& state) {  //  NOLINT
+  size_t ntt_size = state.range(0);
+  size_t modulus = GeneratePrimes(1, 45, ntt_size)[0];
+
+  AlignedVector64<uint64_t> input(ntt_size, 1);
+  AlignedVector64<uint64_t> output(ntt_size, 1);
+  NTT ntt(ntt_size, modulus);
+
+  for (auto _ : state) {
+    ntt.ComputeInverse(input.data(), output.data(), 2, 1);
+  }
+}
+
+BENCHMARK(BM_InvNTTCopy)
     ->Unit(benchmark::kMicrosecond)
     ->Args({1024})
     ->Args({4096})

--- a/test/test-eltwise-fma-mod-avx512.cpp
+++ b/test/test-eltwise-fma-mod-avx512.cpp
@@ -217,7 +217,7 @@ TEST(EltwiseFMAMod, AVX512DQ) {
 
 // Checks AVX512IFMA and native eltwise FMA implementations match
 #ifdef HEXL_HAS_AVX512IFMA
-TEST(EltwiseFMAMod, AVX512) {
+TEST(EltwiseFMAMod, AVX512IFMA) {
   if (!has_avx512ifma) {
     GTEST_SKIP();
   }


### PR DESCRIPTION
1.5x - 1.7x speedup on EltwiseFMAModAVX512IFMA using a few tricks also used in the NTT:

1) Switch to IFMA 52-bit mullo when computing `vq_times_mod`. The speedup is likely due to better pipelining on the same port

2) Use the negative modulus, `neg_p`. This helps compute `q := a * b - q * p` via two steps: `tmp = a * b;  q = fma(tmp, q, neg_p)` rather than the previous three steps: `tmp = a*b; tmp2 = q*p; q = tmp - tmp2` (see line 2 of Algorithm 4 in https://arxiv.org/pdf/2012.01968.pdf for background)

Additionally, for the case when the addition argument `arg3 != nullptr`, merging the two modular reductions led to a slight speedup.
 
On ICX with clang-12, I see
| Benchmark  | Before  | After   | Speedup  |
|---|---|---|---|
| BM_EltwiseFMAModAVX512IFMA/1024/0     | 0.196us   | 0.116us   | 1.69x   |   
| BM_EltwiseFMAModAVX512IFMA/8192/0     | 1.53us      | 1.03us   |  1.48x  |   
| BM_EltwiseFMAModAVX512IFMA/16384/0  | 3.05us     | 2.06us   |  1.51x |   
| BM_EltwiseFMAModAVX512IFMA/1024/1      | 0.268us  | 0.177us  |  1.51x |   
| BM_EltwiseFMAModAVX512IFMA/8192/1      | 2.22us     | 1.47us   |   1.51x |   
| BM_EltwiseFMAModAVX512IFMA/16384/1   | 4.43us    | 2.93us   |   1.51x |   

