### PR TITLE
Native C++ Radix 4 NTT

### DIFF
--- a/benchmark/bench-ntt.cpp
+++ b/benchmark/bench-ntt.cpp
@@ -20,7 +20,7 @@ namespace hexl {
 
 //=================================================================
 
-static void BM_FwdNTTNative(benchmark::State& state) {  //  NOLINT
+static void BM_FwdNTTNativeRadix2(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
   size_t modulus = GeneratePrimes(1, 45, ntt_size)[0];
 
@@ -28,13 +28,13 @@ static void BM_FwdNTTNative(benchmark::State& state) {  //  NOLINT
   NTT ntt(ntt_size, modulus);
 
   for (auto _ : state) {
-    ForwardTransformToBitReverse64(
+    ForwardTransformToBitReverseRadix2(
         input.data(), ntt_size, modulus, ntt.GetRootOfUnityPowers().data(),
         ntt.GetPrecon64RootOfUnityPowers().data(), 2, 1);
   }
 }
 
-BENCHMARK(BM_FwdNTTNative)
+BENCHMARK(BM_FwdNTTNativeRadix2)
     ->Unit(benchmark::kMicrosecond)
     ->Args({1024})
     ->Args({4096})

--- a/benchmark/bench-ntt.cpp
+++ b/benchmark/bench-ntt.cpp
@@ -20,7 +20,6 @@ namespace hexl {
 
 //=================================================================
 
-// state[0] is the degree
 static void BM_FwdNTTNative(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
   size_t modulus = GeneratePrimes(1, 45, ntt_size)[0];
@@ -36,6 +35,27 @@ static void BM_FwdNTTNative(benchmark::State& state) {  //  NOLINT
 }
 
 BENCHMARK(BM_FwdNTTNative)
+    ->Unit(benchmark::kMicrosecond)
+    ->Args({1024})
+    ->Args({4096})
+    ->Args({16384});
+//=================================================================
+
+static void BM_FwdNTTNativeRadix4(benchmark::State& state) {  //  NOLINT
+  size_t ntt_size = state.range(0);
+  size_t modulus = GeneratePrimes(1, 45, ntt_size)[0];
+
+  AlignedVector64<uint64_t> input(ntt_size, 1);
+  NTT ntt(ntt_size, modulus);
+
+  for (auto _ : state) {
+    ForwardTransformToBitReverseRadix4(
+        input.data(), ntt_size, modulus, ntt.GetRootOfUnityPowers().data(),
+        ntt.GetPrecon64RootOfUnityPowers().data(), 2, 1);
+  }
+}
+
+BENCHMARK(BM_FwdNTTNativeRadix4)
     ->Unit(benchmark::kMicrosecond)
     ->Args({1024})
     ->Args({4096})

--- a/hexl/CMakeLists.txt
+++ b/hexl/CMakeLists.txt
@@ -11,6 +11,7 @@ set(NATIVE_SRC
     eltwise/eltwise-cmp-sub-mod.cpp
     ntt/ntt-internal.cpp
     ntt/ntt-default.cpp
+    ntt/ntt-radix-4.cpp
     number-theory/number-theory.cpp
 )
 

--- a/hexl/include/hexl/number-theory/number-theory.hpp
+++ b/hexl/include/hexl/number-theory/number-theory.hpp
@@ -140,12 +140,7 @@ inline uint64_t MultiplyModLazy(uint64_t x, uint64_t y_operand,
   HEXL_CHECK(x <= MaximumValue(BitShift),
              "Operand " << x << " exceeds bound " << MaximumValue(BitShift));
 
-  HEXL_VLOG(3, "MultiplyModLazy x " << x << " y_operand " << y_operand
-                                    << " y_barrett_factor "
-                                    << y_barrett_factor);
-
   uint64_t Q = MultiplyUInt64Hi<BitShift>(x, y_barrett_factor);
-  HEXL_VLOG(3, "Q " << Q);
   return y_operand * x - Q * modulus;
 }
 

--- a/hexl/include/hexl/number-theory/number-theory.hpp
+++ b/hexl/include/hexl/number-theory/number-theory.hpp
@@ -140,7 +140,12 @@ inline uint64_t MultiplyModLazy(uint64_t x, uint64_t y_operand,
   HEXL_CHECK(x <= MaximumValue(BitShift),
              "Operand " << x << " exceeds bound " << MaximumValue(BitShift));
 
+  HEXL_VLOG(3, "MultiplyModLazy x " << x << " y_operand " << y_operand
+                                    << " y_barrett_factor "
+                                    << y_barrett_factor);
+
   uint64_t Q = MultiplyUInt64Hi<BitShift>(x, y_barrett_factor);
+  HEXL_VLOG(3, "Q " << Q);
   return y_operand * x - Q * modulus;
 }
 

--- a/hexl/include/hexl/number-theory/number-theory.hpp
+++ b/hexl/include/hexl/number-theory/number-theory.hpp
@@ -60,6 +60,10 @@ inline uint64_t Log2(uint64_t x) {
   return MSB(x);
 }
 
+inline bool IsPowerOfFour(uint64_t num) {
+  return IsPowerOfTwo(num) && (Log2(num) % 2 == 0);
+}
+
 /// @brief Returns the maximum value that can be represented using \p bits bits
 inline uint64_t MaximumValue(uint64_t bits) {
   HEXL_CHECK(bits <= 64, "MaximumValue requires bits <= 64; got " << bits);

--- a/hexl/include/hexl/util/clang.hpp
+++ b/hexl/include/hexl/util/clang.hpp
@@ -60,7 +60,6 @@ inline uint64_t MSB(uint64_t input) {
 
 #define HEXL_LOOP_UNROLL_4 _Pragma("clang loop unroll_count(4)")
 #define HEXL_LOOP_UNROLL_8 _Pragma("clang loop unroll_count(8)")
-#define HEXL_LOOP_UNROLL_16 _Pragma("clang loop unroll_count(16)")
 
 #endif
 

--- a/hexl/include/hexl/util/clang.hpp
+++ b/hexl/include/hexl/util/clang.hpp
@@ -60,6 +60,7 @@ inline uint64_t MSB(uint64_t input) {
 
 #define HEXL_LOOP_UNROLL_4 _Pragma("clang loop unroll_count(4)")
 #define HEXL_LOOP_UNROLL_8 _Pragma("clang loop unroll_count(8)")
+#define HEXL_LOOP_UNROLL_16 _Pragma("clang loop unroll_count(16)")
 
 #endif
 

--- a/hexl/ntt/ntt-default.cpp
+++ b/hexl/ntt/ntt-default.cpp
@@ -50,6 +50,7 @@ void ForwardTransformToBitReverse64(uint64_t* operand, uint64_t n,
             j1 += (t << 1);
           }
           const uint64_t W = root_of_unity_powers[m + i];
+          HEXL_VLOG(3, "W_idx " << (m + i));
           const uint64_t W_precon = precon_root_of_unity_powers[m + i];
 
           uint64_t* X = operand + j1;
@@ -72,6 +73,7 @@ void ForwardTransformToBitReverse64(uint64_t* operand, uint64_t n,
           }
           const uint64_t W = root_of_unity_powers[m + i];
           const uint64_t W_precon = precon_root_of_unity_powers[m + i];
+          HEXL_VLOG(3, "W_idx " << (m + i));
 
           uint64_t* X = operand + j1;
           uint64_t* Y = X + t;
@@ -89,6 +91,7 @@ void ForwardTransformToBitReverse64(uint64_t* operand, uint64_t n,
           }
           const uint64_t W = root_of_unity_powers[m + i];
           const uint64_t W_precon = precon_root_of_unity_powers[m + i];
+          HEXL_VLOG(3, "W_idx " << (m + i));
 
           uint64_t* X = operand + j1;
           uint64_t* Y = X + t;
@@ -104,6 +107,7 @@ void ForwardTransformToBitReverse64(uint64_t* operand, uint64_t n,
           }
           const uint64_t W = root_of_unity_powers[m + i];
           const uint64_t W_precon = precon_root_of_unity_powers[m + i];
+          HEXL_VLOG(3, "W_idx " << (m + i));
 
           uint64_t* X = operand + j1;
           uint64_t* Y = X + t;
@@ -118,6 +122,7 @@ void ForwardTransformToBitReverse64(uint64_t* operand, uint64_t n,
           }
           const uint64_t W = root_of_unity_powers[m + i];
           const uint64_t W_precon = precon_root_of_unity_powers[m + i];
+          HEXL_VLOG(3, "W_idx " << (m + i));
 
           uint64_t* X = operand + j1;
           uint64_t* Y = X + t;

--- a/hexl/ntt/ntt-default.cpp
+++ b/hexl/ntt/ntt-default.cpp
@@ -50,7 +50,6 @@ void ForwardTransformToBitReverse64(uint64_t* operand, uint64_t n,
             j1 += (t << 1);
           }
           const uint64_t W = root_of_unity_powers[m + i];
-          HEXL_VLOG(3, "W_idx " << (m + i));
           const uint64_t W_precon = precon_root_of_unity_powers[m + i];
 
           uint64_t* X = operand + j1;
@@ -73,7 +72,6 @@ void ForwardTransformToBitReverse64(uint64_t* operand, uint64_t n,
           }
           const uint64_t W = root_of_unity_powers[m + i];
           const uint64_t W_precon = precon_root_of_unity_powers[m + i];
-          HEXL_VLOG(3, "W_idx " << (m + i));
 
           uint64_t* X = operand + j1;
           uint64_t* Y = X + t;
@@ -91,7 +89,6 @@ void ForwardTransformToBitReverse64(uint64_t* operand, uint64_t n,
           }
           const uint64_t W = root_of_unity_powers[m + i];
           const uint64_t W_precon = precon_root_of_unity_powers[m + i];
-          HEXL_VLOG(3, "W_idx " << (m + i));
 
           uint64_t* X = operand + j1;
           uint64_t* Y = X + t;
@@ -107,7 +104,6 @@ void ForwardTransformToBitReverse64(uint64_t* operand, uint64_t n,
           }
           const uint64_t W = root_of_unity_powers[m + i];
           const uint64_t W_precon = precon_root_of_unity_powers[m + i];
-          HEXL_VLOG(3, "W_idx " << (m + i));
 
           uint64_t* X = operand + j1;
           uint64_t* Y = X + t;
@@ -122,7 +118,6 @@ void ForwardTransformToBitReverse64(uint64_t* operand, uint64_t n,
           }
           const uint64_t W = root_of_unity_powers[m + i];
           const uint64_t W_precon = precon_root_of_unity_powers[m + i];
-          HEXL_VLOG(3, "W_idx " << (m + i));
 
           uint64_t* X = operand + j1;
           uint64_t* Y = X + t;

--- a/hexl/ntt/ntt-default.hpp
+++ b/hexl/ntt/ntt-default.hpp
@@ -62,34 +62,32 @@ inline void FwdButterflyLazy(uint64_t* X, uint64_t* Y, uint64_t W,
 
 // Assume X0, X1, X2, X3 in [0, 4q) and return X0, X1, X2, X3 in [0, 4q)
 inline void FwdButterflyRadix4(uint64_t* X0, uint64_t* X1, uint64_t* X2,
-                               uint64_t* X3, MultiplyFactor W1,
-                               MultiplyFactor W2, MultiplyFactor W3,
-                               uint64_t modulus, uint64_t twice_modulus) {
+                               uint64_t* X3, uint64_t W1, uint64_t W1_precon,
+                               uint64_t W2, uint64_t W2_precon, uint64_t W3,
+                               uint64_t W3_precon, uint64_t modulus,
+                               uint64_t twice_modulus,
+                               uint64_t four_times_modulus) {
   HEXL_VLOG(3, "FwdButterflyRadix4");
   // HEXL_VLOG(3, "Xs " << (std::vector<uint64_t>{*X0, *X1, *X2, *X3}));
 
   // if (std::getenv("TEST") != nullptr) {
   {
     // Returns Xs in [0, 4p)
-    FwdButterflyLazy(X0, X2, W1.Operand(), W1.BarrettFactor(), modulus,
-                     twice_modulus);
-    FwdButterflyLazy(X1, X3, W1.Operand(), W1.BarrettFactor(), modulus,
-                     twice_modulus);
+    FwdButterflyLazy(X0, X2, W1, W1_precon, modulus, twice_modulus);
+    FwdButterflyLazy(X1, X3, W1, W1_precon, modulus, twice_modulus);
 
     // Returns Xs in [0, 8p)
-    FwdButterflyLazy(X0, X1, W2.Operand(), W2.BarrettFactor(), modulus,
-                     twice_modulus);
-    FwdButterflyLazy(X2, X3, W3.Operand(), W3.BarrettFactor(), modulus,
-                     twice_modulus);
+    FwdButterflyLazy(X0, X1, W2, W2_precon, modulus, twice_modulus);
+    FwdButterflyLazy(X2, X3, W3, W3_precon, modulus, twice_modulus);
 
     // HEXL_VLOG(3, "Xs after second round "
     //                  << (std::vector<uint64_t>{*X0, *X1, *X2, *X3}));
 
     // Reduce Xs to [0, 4p)
-    *X0 = ReduceMod<2>(*X0, 4 * modulus);
-    *X1 = ReduceMod<2>(*X1, 4 * modulus);
-    *X2 = ReduceMod<2>(*X2, 4 * modulus);
-    *X3 = ReduceMod<2>(*X3, 4 * modulus);
+    *X0 = ReduceMod<2>(*X0, four_times_modulus);
+    *X1 = ReduceMod<2>(*X1, four_times_modulus);
+    *X2 = ReduceMod<2>(*X2, four_times_modulus);
+    *X3 = ReduceMod<2>(*X3, four_times_modulus);
 
     return;
   }

--- a/hexl/ntt/ntt-default.hpp
+++ b/hexl/ntt/ntt-default.hpp
@@ -69,19 +69,25 @@ inline void FwdButterflyRadix4(uint64_t* X0, uint64_t* X1, uint64_t* X2,
                                uint64_t four_times_modulus) {
   HEXL_VLOG(3, "FwdButterflyRadix4");
 
+  FwdButterfly(X0, X2, W1, W1_precon, modulus, twice_modulus);
+  FwdButterfly(X1, X3, W1, W1_precon, modulus, twice_modulus);
+  FwdButterfly(X0, X1, W2, W2_precon, modulus, twice_modulus);
+  FwdButterfly(X2, X3, W3, W3_precon, modulus, twice_modulus);
+
+  // Alternate implementation
   // Returns Xs in [0, 6q)
-  FwdButterflyLazy(X0, X2, W1, W1_precon, modulus, twice_modulus);
-  FwdButterflyLazy(X1, X3, W1, W1_precon, modulus, twice_modulus);
+  // FwdButterflyLazy(X0, X2, W1, W1_precon, modulus, twice_modulus);
+  // FwdButterflyLazy(X1, X3, W1, W1_precon, modulus, twice_modulus);
 
-  // Returns Xs in [0, 8q)
-  FwdButterflyLazy(X0, X1, W2, W2_precon, modulus, twice_modulus);
-  FwdButterflyLazy(X2, X3, W3, W3_precon, modulus, twice_modulus);
+  // // Returns Xs in [0, 8q)
+  // FwdButterflyLazy(X0, X1, W2, W2_precon, modulus, twice_modulus);
+  // FwdButterflyLazy(X2, X3, W3, W3_precon, modulus, twice_modulus);
 
-  // Reduce Xs to [0, 4q)
-  *X0 = ReduceMod<2>(*X0, four_times_modulus);
-  *X1 = ReduceMod<2>(*X1, four_times_modulus);
-  *X2 = ReduceMod<2>(*X2, four_times_modulus);
-  *X3 = ReduceMod<2>(*X3, four_times_modulus);
+  // // Reduce Xs to [0, 4q)
+  // *X0 = ReduceMod<2>(*X0, four_times_modulus);
+  // *X1 = ReduceMod<2>(*X1, four_times_modulus);
+  // *X2 = ReduceMod<2>(*X2, four_times_modulus);
+  // *X3 = ReduceMod<2>(*X3, four_times_modulus);
 }
 
 /// @brief The Harvey butterfly: assume X, Y in [0, 2q), and return X', Y' in

--- a/hexl/ntt/ntt-default.hpp
+++ b/hexl/ntt/ntt-default.hpp
@@ -42,8 +42,8 @@ inline void FwdButterfly(uint64_t* X, uint64_t* Y, uint64_t W,
   HEXL_VLOG(3, "Output X " << *X << ", Y " << *Y);
 }
 
-// Assume X, Y in [0, np) and return X', Y' in [0, (n+2)p)
-// such that X' = X + WY mod p and Y' = X - WY mod p
+// Assume X, Y in [0, n*q) and return X', Y' in [0, (n+2)*q)
+// such that X' = X + WY mod q and Y' = X - WY mod q
 inline void FwdButterflyLazy(uint64_t* X, uint64_t* Y, uint64_t W,
                              uint64_t W_precon, uint64_t modulus,
                              uint64_t twice_modulus) {
@@ -69,15 +69,15 @@ inline void FwdButterflyRadix4(uint64_t* X0, uint64_t* X1, uint64_t* X2,
                                uint64_t four_times_modulus) {
   HEXL_VLOG(3, "FwdButterflyRadix4");
 
-  // Returns Xs in [0, 6p)
+  // Returns Xs in [0, 6q)
   FwdButterflyLazy(X0, X2, W1, W1_precon, modulus, twice_modulus);
   FwdButterflyLazy(X1, X3, W1, W1_precon, modulus, twice_modulus);
 
-  // Returns Xs in [0, 8p)
+  // Returns Xs in [0, 8q)
   FwdButterflyLazy(X0, X1, W2, W2_precon, modulus, twice_modulus);
   FwdButterflyLazy(X2, X3, W3, W3_precon, modulus, twice_modulus);
 
-  // Reduce Xs to [0, 4p)
+  // Reduce Xs to [0, 4q)
   *X0 = ReduceMod<2>(*X0, four_times_modulus);
   *X1 = ReduceMod<2>(*X1, four_times_modulus);
   *X2 = ReduceMod<2>(*X2, four_times_modulus);

--- a/hexl/ntt/ntt-default.hpp
+++ b/hexl/ntt/ntt-default.hpp
@@ -30,14 +30,19 @@ namespace hexl {
 inline void FwdButterfly(uint64_t* X, uint64_t* Y, uint64_t W,
                          uint64_t W_precon, uint64_t modulus,
                          uint64_t twice_modulus) {
-  HEXL_VLOG(3, "FwdButterfly with W " << W << ", W_precon " << W_precon);
+  HEXL_VLOG(3, "FwdButterfly");
+  HEXL_VLOG(3, "Inputs: X " << *X << ", Y " << *Y << ", W " << W << ", modulus "
+                            << modulus);
   uint64_t tx = (*X >= twice_modulus) ? (*X - twice_modulus) : *X;
   uint64_t T = MultiplyModLazy<64>(*Y, W, W_precon, modulus);
+  HEXL_VLOG(3, "T " << T);
   *X = tx + T;
   *Y = tx + twice_modulus - T;
+
+  HEXL_VLOG(3, "Output X " << *X << ", Y " << *Y);
 }
 
-// Assume X, Y in [0, np] and return X', Y' in [0, (n+2)p]
+// Assume X, Y in [0, np) and return X', Y' in [0, (n+2)p)
 // such that X' = X + WY mod p and Y' = X - WY mod p
 inline void FwdButterflyLazy(uint64_t* X, uint64_t* Y, uint64_t W,
                              uint64_t W_precon, uint64_t modulus,
@@ -55,7 +60,7 @@ inline void FwdButterflyLazy(uint64_t* X, uint64_t* Y, uint64_t W,
   HEXL_VLOG(3, "Outputs: X " << *X << ", Y " << *Y);
 }
 
-// Assume X0, X1, X2, X3 in [0, 4q] and return X0, X1, X2, X3 in [0, 4q)
+// Assume X0, X1, X2, X3 in [0, 4q) and return X0, X1, X2, X3 in [0, 4q)
 inline void FwdButterflyRadix4(uint64_t* X0, uint64_t* X1, uint64_t* X2,
                                uint64_t* X3, uint64_t W1, uint64_t W2,
                                uint64_t W3, uint64_t modulus,

--- a/hexl/ntt/ntt-default.hpp
+++ b/hexl/ntt/ntt-default.hpp
@@ -36,6 +36,48 @@ inline void FwdButterfly(uint64_t* X, uint64_t* Y, uint64_t W,
   *Y = tx + twice_modulus - T;
 }
 
+inline void FwdButterflyRadix4(uint64_t* X0, uint64_t* X1, uint64_t* X2,
+                               uint64_t* X3, uint64_t W1, uint64_t W2,
+                               uint64_t W3, uint64_t modulus,
+                               uint64_t twice_modulus) {
+  uint64_t a0 = *X0;
+  uint64_t a1 = MultiplyMod(*X1, W1, modulus);
+  uint64_t a2 = MultiplyMod(*X2, W2, modulus);
+  uint64_t a3 = MultiplyMod(*X3, W3, modulus);
+
+  HEXL_VLOG(3, "as " << (std::vector<uint64_t>{a0, a1, a2, a3}));
+
+  uint64_t W1_x_x2 = MultiplyMod(W1, *X2, modulus);
+  uint64_t tmp0 = AddUIntMod(*X0, W1_x_x2, modulus);
+  uint64_t tmp2 = SubUIntMod(*X0, W1_x_x2, modulus);
+  HEXL_VLOG(3, "W1_x_x2 " << W1_x_x2);
+  HEXL_VLOG(3, "tmp0 " << tmp0);
+  HEXL_VLOG(3, "tmp2 " << tmp2);
+
+  uint64_t W1_x_x3 = MultiplyMod(W1, *X3, modulus);
+  HEXL_VLOG(3, "W1_x_x4 " << W1_x_x3);
+
+  uint64_t tmp1 = AddUIntMod(*X1, W1_x_x3, modulus);
+  uint64_t tmp3 = SubUIntMod(*X1, W1_x_x3, modulus);
+  HEXL_VLOG(3, "tmp1 " << tmp1);
+  HEXL_VLOG(3, "tmp3 " << tmp3);
+
+  uint64_t tmp1_x_W2 = MultiplyMod(tmp1, W2, modulus);
+  uint64_t Y0 = AddUIntMod(tmp0, tmp1_x_W2, modulus);
+  uint64_t Y1 = SubUIntMod(tmp0, tmp1_x_W2, modulus);
+
+  uint64_t tmp3_x_W2 = MultiplyMod(tmp3, W3, modulus);
+  uint64_t Y2 = AddUIntMod(tmp2, tmp3_x_W2, modulus);
+  uint64_t Y3 = SubUIntMod(tmp2, tmp3_x_W2, modulus);
+
+  *X0 = Y0;
+  *X1 = Y1;
+  *X2 = Y2;
+  *X3 = Y3;
+
+  HEXL_VLOG(3, "Ys " << (std::vector<uint64_t>{Y0, Y1, Y2, Y3}));
+}
+
 /// @brief The Harvey butterfly: assume X, Y in [0, 2q), and return X', Y' in
 /// [0, 2q) such that X' = X + Y (mod q), Y' = W(X - Y) (mod q).
 /// @param[in,out] X Butterfly data

--- a/hexl/ntt/ntt-default.hpp
+++ b/hexl/ntt/ntt-default.hpp
@@ -33,7 +33,7 @@ inline void FwdButterfly(uint64_t* X, uint64_t* Y, uint64_t W,
   HEXL_VLOG(3, "FwdButterfly");
   HEXL_VLOG(3, "Inputs: X " << *X << ", Y " << *Y << ", W " << W << ", modulus "
                             << modulus);
-  uint64_t tx = (*X >= twice_modulus) ? (*X - twice_modulus) : *X;
+  uint64_t tx = ReduceMod<2>(*X, twice_modulus);
   uint64_t T = MultiplyModLazy<64>(*Y, W, W_precon, modulus);
   HEXL_VLOG(3, "T " << T);
   *X = tx + T;
@@ -68,6 +68,7 @@ inline void FwdButterflyRadix4(uint64_t* X0, uint64_t* X1, uint64_t* X2,
                                uint64_t twice_modulus,
                                uint64_t four_times_modulus) {
   HEXL_VLOG(3, "FwdButterflyRadix4");
+  HEXL_UNUSED(four_times_modulus);
 
   FwdButterfly(X0, X2, W1, W1_precon, modulus, twice_modulus);
   FwdButterfly(X1, X3, W1, W1_precon, modulus, twice_modulus);
@@ -75,7 +76,7 @@ inline void FwdButterflyRadix4(uint64_t* X0, uint64_t* X1, uint64_t* X2,
   FwdButterfly(X2, X3, W3, W3_precon, modulus, twice_modulus);
 
   // Alternate implementation
-  // Returns Xs in [0, 6q)
+  // // Returns Xs in [0, 6q)
   // FwdButterflyLazy(X0, X2, W1, W1_precon, modulus, twice_modulus);
   // FwdButterflyLazy(X1, X3, W1, W1_precon, modulus, twice_modulus);
 
@@ -108,7 +109,7 @@ inline void InvButterfly(uint64_t* X, uint64_t* Y, uint64_t W,
   uint64_t tx = *X + *Y;
   uint64_t ty = *X + twice_modulus - *Y;
 
-  *X = (tx >= twice_modulus) ? (tx - twice_modulus) : tx;
+  *X = ReduceMod<2>(tx, twice_modulus);
   *Y = MultiplyModLazy<64>(ty, W, W_precon, modulus);
 }
 

--- a/hexl/ntt/ntt-default.hpp
+++ b/hexl/ntt/ntt-default.hpp
@@ -66,7 +66,7 @@ inline void FwdButterflyRadix4(uint64_t* X0, uint64_t* X1, uint64_t* X2,
                                uint64_t W3, uint64_t modulus,
                                uint64_t twice_modulus) {
   HEXL_VLOG(3, "FwdButterflyRadix4");
-  HEXL_VLOG(3, "Xs " << (std::vector<uint64_t>{*X0, *X1, *X2, *X3}));
+  // HEXL_VLOG(3, "Xs " << (std::vector<uint64_t>{*X0, *X1, *X2, *X3}));
 
   if (std::getenv("TEST") != nullptr) {
     // {
@@ -78,19 +78,19 @@ inline void FwdButterflyRadix4(uint64_t* X0, uint64_t* X1, uint64_t* X2,
     FwdButterflyLazy(X0, X2, W1, W1_precon, modulus, twice_modulus);
     FwdButterflyLazy(X1, X3, W1, W1_precon, modulus, twice_modulus);
 
-    HEXL_VLOG(3, "W1_precon " << W1_precon);
+    // HEXL_VLOG(3, "W1_precon " << W1_precon);
 
-    HEXL_VLOG(3, "tmp0 " << *X0);
-    HEXL_VLOG(3, "tmp1 " << *X1);
-    HEXL_VLOG(3, "tmp2 " << *X2);
-    HEXL_VLOG(3, "tmp3 " << *X3);
+    // HEXL_VLOG(3, "tmp0 " << *X0);
+    // HEXL_VLOG(3, "tmp1 " << *X1);
+    // HEXL_VLOG(3, "tmp2 " << *X2);
+    // HEXL_VLOG(3, "tmp3 " << *X3);
 
     // Returns Xs in [0, 8p)
     FwdButterflyLazy(X0, X1, W2, W2_precon, modulus, twice_modulus);
     FwdButterflyLazy(X2, X3, W3, W3_precon, modulus, twice_modulus);
 
-    HEXL_VLOG(3, "Xs after second round "
-                     << (std::vector<uint64_t>{*X0, *X1, *X2, *X3}));
+    // HEXL_VLOG(3, "Xs after second round "
+    //                  << (std::vector<uint64_t>{*X0, *X1, *X2, *X3}));
 
     // Reduce Xs to [0, 4p)
     *X0 = ReduceMod<2>(*X0, 4 * modulus);
@@ -106,22 +106,22 @@ inline void FwdButterflyRadix4(uint64_t* X0, uint64_t* X1, uint64_t* X2,
   uint64_t a2 = MultiplyMod(*X2, W2, modulus);
   uint64_t a3 = MultiplyMod(*X3, W3, modulus);
 
-  HEXL_VLOG(3, "as " << (std::vector<uint64_t>{a0, a1, a2, a3}));
+  HEXL_VLOG(5, "as " << (std::vector<uint64_t>{a0, a1, a2, a3}));
 
   uint64_t W1_x_x2 = MultiplyMod(W1, *X2, modulus);
   uint64_t tmp0 = AddUIntMod(*X0, W1_x_x2, modulus);
   uint64_t tmp2 = SubUIntMod(*X0, W1_x_x2, modulus);
-  HEXL_VLOG(3, "W1_x_x2 " << W1_x_x2);
-  HEXL_VLOG(3, "tmp0 " << tmp0);
-  HEXL_VLOG(3, "tmp2 " << tmp2);
+  HEXL_VLOG(5, "W1_x_x2 " << W1_x_x2);
+  HEXL_VLOG(5, "tmp0 " << tmp0);
+  HEXL_VLOG(5, "tmp2 " << tmp2);
 
   uint64_t W1_x_x3 = MultiplyMod(W1, *X3, modulus);
-  HEXL_VLOG(3, "W1_x_x4 " << W1_x_x3);
+  HEXL_VLOG(5, "W1_x_x4 " << W1_x_x3);
 
   uint64_t tmp1 = AddUIntMod(*X1, W1_x_x3, modulus);
   uint64_t tmp3 = SubUIntMod(*X1, W1_x_x3, modulus);
-  HEXL_VLOG(3, "tmp1 " << tmp1);
-  HEXL_VLOG(3, "tmp3 " << tmp3);
+  HEXL_VLOG(5, "tmp1 " << tmp1);
+  HEXL_VLOG(5, "tmp3 " << tmp3);
 
   uint64_t tmp1_x_W2 = MultiplyMod(tmp1, W2, modulus);
   uint64_t Y0 = AddUIntMod(tmp0, tmp1_x_W2, modulus);
@@ -136,7 +136,7 @@ inline void FwdButterflyRadix4(uint64_t* X0, uint64_t* X1, uint64_t* X2,
   *X2 = Y2;
   *X3 = Y3;
 
-  HEXL_VLOG(3, "Ys " << (std::vector<uint64_t>{Y0, Y1, Y2, Y3}));
+  HEXL_VLOG(5, "Ys " << (std::vector<uint64_t>{Y0, Y1, Y2, Y3}));
 }
 
 /// @brief The Harvey butterfly: assume X, Y in [0, 2q), and return X', Y' in

--- a/hexl/ntt/ntt-default.hpp
+++ b/hexl/ntt/ntt-default.hpp
@@ -68,68 +68,20 @@ inline void FwdButterflyRadix4(uint64_t* X0, uint64_t* X1, uint64_t* X2,
                                uint64_t twice_modulus,
                                uint64_t four_times_modulus) {
   HEXL_VLOG(3, "FwdButterflyRadix4");
-  // HEXL_VLOG(3, "Xs " << (std::vector<uint64_t>{*X0, *X1, *X2, *X3}));
 
-  // if (std::getenv("TEST") != nullptr) {
-  {
-    // Returns Xs in [0, 4p)
-    FwdButterflyLazy(X0, X2, W1, W1_precon, modulus, twice_modulus);
-    FwdButterflyLazy(X1, X3, W1, W1_precon, modulus, twice_modulus);
+  // Returns Xs in [0, 6p)
+  FwdButterflyLazy(X0, X2, W1, W1_precon, modulus, twice_modulus);
+  FwdButterflyLazy(X1, X3, W1, W1_precon, modulus, twice_modulus);
 
-    // Returns Xs in [0, 8p)
-    FwdButterflyLazy(X0, X1, W2, W2_precon, modulus, twice_modulus);
-    FwdButterflyLazy(X2, X3, W3, W3_precon, modulus, twice_modulus);
+  // Returns Xs in [0, 8p)
+  FwdButterflyLazy(X0, X1, W2, W2_precon, modulus, twice_modulus);
+  FwdButterflyLazy(X2, X3, W3, W3_precon, modulus, twice_modulus);
 
-    // HEXL_VLOG(3, "Xs after second round "
-    //                  << (std::vector<uint64_t>{*X0, *X1, *X2, *X3}));
-
-    // Reduce Xs to [0, 4p)
-    *X0 = ReduceMod<2>(*X0, four_times_modulus);
-    *X1 = ReduceMod<2>(*X1, four_times_modulus);
-    *X2 = ReduceMod<2>(*X2, four_times_modulus);
-    *X3 = ReduceMod<2>(*X3, four_times_modulus);
-
-    return;
-  }
-
-  // {
-  // uint64_t a0 = *X0;
-  // uint64_t a1 = MultiplyMod(*X1, W1, modulus);
-  // uint64_t a2 = MultiplyMod(*X2, W2, modulus);
-  // uint64_t a3 = MultiplyMod(*X3, W3, modulus);
-
-  // HEXL_VLOG(5, "as " << (std::vector<uint64_t>{a0, a1, a2, a3}));
-
-  // uint64_t W1_x_x2 = MultiplyMod(W1, *X2, modulus);
-  // uint64_t tmp0 = AddUIntMod(*X0, W1_x_x2, modulus);
-  // uint64_t tmp2 = SubUIntMod(*X0, W1_x_x2, modulus);
-  // HEXL_VLOG(5, "W1_x_x2 " << W1_x_x2);
-  // HEXL_VLOG(5, "tmp0 " << tmp0);
-  // HEXL_VLOG(5, "tmp2 " << tmp2);
-
-  // uint64_t W1_x_x3 = MultiplyMod(W1, *X3, modulus);
-  // HEXL_VLOG(5, "W1_x_x4 " << W1_x_x3);
-
-  // uint64_t tmp1 = AddUIntMod(*X1, W1_x_x3, modulus);
-  // uint64_t tmp3 = SubUIntMod(*X1, W1_x_x3, modulus);
-  // HEXL_VLOG(5, "tmp1 " << tmp1);
-  // HEXL_VLOG(5, "tmp3 " << tmp3);
-
-  // uint64_t tmp1_x_W2 = MultiplyMod(tmp1, W2, modulus);
-  // uint64_t Y0 = AddUIntMod(tmp0, tmp1_x_W2, modulus);
-  // uint64_t Y1 = SubUIntMod(tmp0, tmp1_x_W2, modulus);
-
-  // uint64_t tmp3_x_W2 = MultiplyMod(tmp3, W3, modulus);
-  // uint64_t Y2 = AddUIntMod(tmp2, tmp3_x_W2, modulus);
-  // uint64_t Y3 = SubUIntMod(tmp2, tmp3_x_W2, modulus);
-
-  // *X0 = Y0;
-  // *X1 = Y1;
-  // *X2 = Y2;
-  // *X3 = Y3;
-
-  // HEXL_VLOG(5, "Ys " << (std::vector<uint64_t>{Y0, Y1, Y2, Y3}));
-  // }
+  // Reduce Xs to [0, 4p)
+  *X0 = ReduceMod<2>(*X0, four_times_modulus);
+  *X1 = ReduceMod<2>(*X1, four_times_modulus);
+  *X2 = ReduceMod<2>(*X2, four_times_modulus);
+  *X3 = ReduceMod<2>(*X3, four_times_modulus);
 }
 
 /// @brief The Harvey butterfly: assume X, Y in [0, 2q), and return X', Y' in

--- a/hexl/ntt/ntt-default.hpp
+++ b/hexl/ntt/ntt-default.hpp
@@ -62,32 +62,25 @@ inline void FwdButterflyLazy(uint64_t* X, uint64_t* Y, uint64_t W,
 
 // Assume X0, X1, X2, X3 in [0, 4q) and return X0, X1, X2, X3 in [0, 4q)
 inline void FwdButterflyRadix4(uint64_t* X0, uint64_t* X1, uint64_t* X2,
-                               uint64_t* X3, uint64_t W1, uint64_t W2,
-                               uint64_t W3, uint64_t modulus,
-                               uint64_t twice_modulus) {
+                               uint64_t* X3, MultiplyFactor W1,
+                               MultiplyFactor W2, MultiplyFactor W3,
+                               uint64_t modulus, uint64_t twice_modulus) {
   HEXL_VLOG(3, "FwdButterflyRadix4");
   // HEXL_VLOG(3, "Xs " << (std::vector<uint64_t>{*X0, *X1, *X2, *X3}));
 
-  if (std::getenv("TEST") != nullptr) {
-    // {
-    uint64_t W1_precon = MultiplyFactor(W1, 64, modulus).BarrettFactor();
-    uint64_t W2_precon = MultiplyFactor(W2, 64, modulus).BarrettFactor();
-    uint64_t W3_precon = MultiplyFactor(W3, 64, modulus).BarrettFactor();
-
+  // if (std::getenv("TEST") != nullptr) {
+  {
     // Returns Xs in [0, 4p)
-    FwdButterflyLazy(X0, X2, W1, W1_precon, modulus, twice_modulus);
-    FwdButterflyLazy(X1, X3, W1, W1_precon, modulus, twice_modulus);
-
-    // HEXL_VLOG(3, "W1_precon " << W1_precon);
-
-    // HEXL_VLOG(3, "tmp0 " << *X0);
-    // HEXL_VLOG(3, "tmp1 " << *X1);
-    // HEXL_VLOG(3, "tmp2 " << *X2);
-    // HEXL_VLOG(3, "tmp3 " << *X3);
+    FwdButterflyLazy(X0, X2, W1.Operand(), W1.BarrettFactor(), modulus,
+                     twice_modulus);
+    FwdButterflyLazy(X1, X3, W1.Operand(), W1.BarrettFactor(), modulus,
+                     twice_modulus);
 
     // Returns Xs in [0, 8p)
-    FwdButterflyLazy(X0, X1, W2, W2_precon, modulus, twice_modulus);
-    FwdButterflyLazy(X2, X3, W3, W3_precon, modulus, twice_modulus);
+    FwdButterflyLazy(X0, X1, W2.Operand(), W2.BarrettFactor(), modulus,
+                     twice_modulus);
+    FwdButterflyLazy(X2, X3, W3.Operand(), W3.BarrettFactor(), modulus,
+                     twice_modulus);
 
     // HEXL_VLOG(3, "Xs after second round "
     //                  << (std::vector<uint64_t>{*X0, *X1, *X2, *X3}));
@@ -101,42 +94,44 @@ inline void FwdButterflyRadix4(uint64_t* X0, uint64_t* X1, uint64_t* X2,
     return;
   }
 
-  uint64_t a0 = *X0;
-  uint64_t a1 = MultiplyMod(*X1, W1, modulus);
-  uint64_t a2 = MultiplyMod(*X2, W2, modulus);
-  uint64_t a3 = MultiplyMod(*X3, W3, modulus);
+  // {
+  // uint64_t a0 = *X0;
+  // uint64_t a1 = MultiplyMod(*X1, W1, modulus);
+  // uint64_t a2 = MultiplyMod(*X2, W2, modulus);
+  // uint64_t a3 = MultiplyMod(*X3, W3, modulus);
 
-  HEXL_VLOG(5, "as " << (std::vector<uint64_t>{a0, a1, a2, a3}));
+  // HEXL_VLOG(5, "as " << (std::vector<uint64_t>{a0, a1, a2, a3}));
 
-  uint64_t W1_x_x2 = MultiplyMod(W1, *X2, modulus);
-  uint64_t tmp0 = AddUIntMod(*X0, W1_x_x2, modulus);
-  uint64_t tmp2 = SubUIntMod(*X0, W1_x_x2, modulus);
-  HEXL_VLOG(5, "W1_x_x2 " << W1_x_x2);
-  HEXL_VLOG(5, "tmp0 " << tmp0);
-  HEXL_VLOG(5, "tmp2 " << tmp2);
+  // uint64_t W1_x_x2 = MultiplyMod(W1, *X2, modulus);
+  // uint64_t tmp0 = AddUIntMod(*X0, W1_x_x2, modulus);
+  // uint64_t tmp2 = SubUIntMod(*X0, W1_x_x2, modulus);
+  // HEXL_VLOG(5, "W1_x_x2 " << W1_x_x2);
+  // HEXL_VLOG(5, "tmp0 " << tmp0);
+  // HEXL_VLOG(5, "tmp2 " << tmp2);
 
-  uint64_t W1_x_x3 = MultiplyMod(W1, *X3, modulus);
-  HEXL_VLOG(5, "W1_x_x4 " << W1_x_x3);
+  // uint64_t W1_x_x3 = MultiplyMod(W1, *X3, modulus);
+  // HEXL_VLOG(5, "W1_x_x4 " << W1_x_x3);
 
-  uint64_t tmp1 = AddUIntMod(*X1, W1_x_x3, modulus);
-  uint64_t tmp3 = SubUIntMod(*X1, W1_x_x3, modulus);
-  HEXL_VLOG(5, "tmp1 " << tmp1);
-  HEXL_VLOG(5, "tmp3 " << tmp3);
+  // uint64_t tmp1 = AddUIntMod(*X1, W1_x_x3, modulus);
+  // uint64_t tmp3 = SubUIntMod(*X1, W1_x_x3, modulus);
+  // HEXL_VLOG(5, "tmp1 " << tmp1);
+  // HEXL_VLOG(5, "tmp3 " << tmp3);
 
-  uint64_t tmp1_x_W2 = MultiplyMod(tmp1, W2, modulus);
-  uint64_t Y0 = AddUIntMod(tmp0, tmp1_x_W2, modulus);
-  uint64_t Y1 = SubUIntMod(tmp0, tmp1_x_W2, modulus);
+  // uint64_t tmp1_x_W2 = MultiplyMod(tmp1, W2, modulus);
+  // uint64_t Y0 = AddUIntMod(tmp0, tmp1_x_W2, modulus);
+  // uint64_t Y1 = SubUIntMod(tmp0, tmp1_x_W2, modulus);
 
-  uint64_t tmp3_x_W2 = MultiplyMod(tmp3, W3, modulus);
-  uint64_t Y2 = AddUIntMod(tmp2, tmp3_x_W2, modulus);
-  uint64_t Y3 = SubUIntMod(tmp2, tmp3_x_W2, modulus);
+  // uint64_t tmp3_x_W2 = MultiplyMod(tmp3, W3, modulus);
+  // uint64_t Y2 = AddUIntMod(tmp2, tmp3_x_W2, modulus);
+  // uint64_t Y3 = SubUIntMod(tmp2, tmp3_x_W2, modulus);
 
-  *X0 = Y0;
-  *X1 = Y1;
-  *X2 = Y2;
-  *X3 = Y3;
+  // *X0 = Y0;
+  // *X1 = Y1;
+  // *X2 = Y2;
+  // *X3 = Y3;
 
-  HEXL_VLOG(5, "Ys " << (std::vector<uint64_t>{Y0, Y1, Y2, Y3}));
+  // HEXL_VLOG(5, "Ys " << (std::vector<uint64_t>{Y0, Y1, Y2, Y3}));
+  // }
 }
 
 /// @brief The Harvey butterfly: assume X, Y in [0, 2q), and return X', Y' in

--- a/hexl/ntt/ntt-internal.cpp
+++ b/hexl/ntt/ntt-internal.cpp
@@ -245,14 +245,14 @@ void NTT::ComputeForward(uint64_t* result, const uint64_t* operand,
   }
 #endif
 
-  HEXL_VLOG(3, "Calling 64-bit default FwdNTT");
+  HEXL_VLOG(3, "Calling ForwardTransformToBitReverseRadix2");
   const uint64_t* root_of_unity_powers = GetRootOfUnityPowers().data();
   const uint64_t* precon_root_of_unity_powers =
       GetPrecon64RootOfUnityPowers().data();
 
-  ForwardTransformToBitReverse64(result, m_degree, m_q, root_of_unity_powers,
-                                 precon_root_of_unity_powers, input_mod_factor,
-                                 output_mod_factor);
+  ForwardTransformToBitReverseRadix2(
+      result, m_degree, m_q, root_of_unity_powers, precon_root_of_unity_powers,
+      input_mod_factor, output_mod_factor);
 }
 
 void NTT::ComputeInverse(uint64_t* result, const uint64_t* operand,

--- a/hexl/ntt/ntt-internal.cpp
+++ b/hexl/ntt/ntt-internal.cpp
@@ -205,54 +205,64 @@ void NTT::ComputeForward(uint64_t* result, const uint64_t* operand,
     std::memcpy(result, operand, m_degree * sizeof(uint64_t));
   }
 
-#ifdef HEXL_HAS_AVX512IFMA
-  if (has_avx512ifma && (m_q < s_max_fwd_ifma_modulus && (m_degree >= 16))) {
-    const uint64_t* root_of_unity_powers = GetAVX512RootOfUnityPowers().data();
-    const uint64_t* precon_root_of_unity_powers =
-        GetAVX512Precon52RootOfUnityPowers().data();
+  // #ifdef HEXL_HAS_AVX512IFMA
+  //   if (has_avx512ifma && (m_q < s_max_fwd_ifma_modulus && (m_degree >= 16)))
+  //   {
+  //     const uint64_t* root_of_unity_powers =
+  //     GetAVX512RootOfUnityPowers().data(); const uint64_t*
+  //     precon_root_of_unity_powers =
+  //         GetAVX512Precon52RootOfUnityPowers().data();
 
-    HEXL_VLOG(3, "Calling 52-bit AVX512-IFMA FwdNTT");
-    ForwardTransformToBitReverseAVX512<s_ifma_shift_bits>(
-        result, m_degree, m_q, root_of_unity_powers,
-        precon_root_of_unity_powers, input_mod_factor, output_mod_factor);
-    return;
-  }
-#endif
+  //     HEXL_VLOG(3, "Calling 52-bit AVX512-IFMA FwdNTT");
+  //     ForwardTransformToBitReverseAVX512<s_ifma_shift_bits>(
+  //         result, m_degree, m_q, root_of_unity_powers,
+  //         precon_root_of_unity_powers, input_mod_factor, output_mod_factor);
+  //     return;
+  //   }
+  // #endif
 
-#ifdef HEXL_HAS_AVX512DQ
-  if (has_avx512dq && m_degree >= 16) {
-    if (m_q < s_max_fwd_32_modulus) {
-      HEXL_VLOG(3, "Calling 32-bit AVX512-DQ FwdNTT");
-      const uint64_t* root_of_unity_powers =
-          GetAVX512RootOfUnityPowers().data();
-      const uint64_t* precon_root_of_unity_powers =
-          GetAVX512Precon32RootOfUnityPowers().data();
-      ForwardTransformToBitReverseAVX512<32>(
-          result, m_degree, m_q, root_of_unity_powers,
-          precon_root_of_unity_powers, input_mod_factor, output_mod_factor);
-    } else {
-      HEXL_VLOG(3, "Calling 64-bit AVX512-DQ FwdNTT");
-      const uint64_t* root_of_unity_powers =
-          GetAVX512RootOfUnityPowers().data();
-      const uint64_t* precon_root_of_unity_powers =
-          GetAVX512Precon64RootOfUnityPowers().data();
+  // #ifdef HEXL_HAS_AVX512DQ
+  //   if (has_avx512dq && m_degree >= 16) {
+  //     if (m_q < s_max_fwd_32_modulus) {
+  //       HEXL_VLOG(3, "Calling 32-bit AVX512-DQ FwdNTT");
+  //       const uint64_t* root_of_unity_powers =
+  //           GetAVX512RootOfUnityPowers().data();
+  //       const uint64_t* precon_root_of_unity_powers =
+  //           GetAVX512Precon32RootOfUnityPowers().data();
+  //       ForwardTransformToBitReverseAVX512<32>(
+  //           result, m_degree, m_q, root_of_unity_powers,
+  //           precon_root_of_unity_powers, input_mod_factor,
+  //           output_mod_factor);
+  //     } else {
+  //       HEXL_VLOG(3, "Calling 64-bit AVX512-DQ FwdNTT");
+  //       const uint64_t* root_of_unity_powers =
+  //           GetAVX512RootOfUnityPowers().data();
+  //       const uint64_t* precon_root_of_unity_powers =
+  //           GetAVX512Precon64RootOfUnityPowers().data();
 
-      ForwardTransformToBitReverseAVX512<s_default_shift_bits>(
-          result, m_degree, m_q, root_of_unity_powers,
-          precon_root_of_unity_powers, input_mod_factor, output_mod_factor);
-    }
-    return;
-  }
-#endif
+  //       ForwardTransformToBitReverseAVX512<s_default_shift_bits>(
+  //           result, m_degree, m_q, root_of_unity_powers,
+  //           precon_root_of_unity_powers, input_mod_factor,
+  //           output_mod_factor);
+  //     }
+  //     return;
+  //   }
+  // #endif
 
   HEXL_VLOG(3, "Calling 64-bit default FwdNTT");
   const uint64_t* root_of_unity_powers = GetRootOfUnityPowers().data();
   const uint64_t* precon_root_of_unity_powers =
       GetPrecon64RootOfUnityPowers().data();
 
-  ForwardTransformToBitReverse64(result, m_degree, m_q, root_of_unity_powers,
-                                 precon_root_of_unity_powers, input_mod_factor,
-                                 output_mod_factor);
+  if (std::getenv("RAD4") == nullptr) {
+    ForwardTransformToBitReverse64(result, m_degree, m_q, root_of_unity_powers,
+                                   precon_root_of_unity_powers,
+                                   input_mod_factor, output_mod_factor);
+  } else {
+    ForwardTransformToBitReverseRadix4(
+        result, m_degree, m_q, root_of_unity_powers,
+        precon_root_of_unity_powers, input_mod_factor, output_mod_factor);
+  }
 }
 
 void NTT::ComputeInverse(uint64_t* result, const uint64_t* operand,

--- a/hexl/ntt/ntt-internal.hpp
+++ b/hexl/ntt/ntt-internal.hpp
@@ -17,7 +17,7 @@
 namespace intel {
 namespace hexl {
 
-/// @brief Default C++ NTT implementation of the forward NTT
+/// @brief Radix-4 C++ NTT implementation of the forward NTT
 /// @param[in, out] operand Input data. Overwritten with NTT output
 /// @param[in] n Size of the transform, i.e. the polynomial degree. Must be a
 /// power of two.
@@ -30,12 +30,11 @@ namespace hexl {
 /// input_mod_factor * q)
 /// @param[in] output_mod_factor Upper bound for result; result must be in [0,
 /// output_mod_factor * q)
-void ForwardTransformToBitReverse64(uint64_t* operand, uint64_t n,
-                                    uint64_t modulus,
-                                    const uint64_t* root_of_unity_powers,
-                                    const uint64_t* precon_root_of_unity_powers,
-                                    uint64_t input_mod_factor = 1,
-                                    uint64_t output_mod_factor = 1);
+void ForwardTransformToBitReverseRadix2(
+    uint64_t* operand, uint64_t n, uint64_t modulus,
+    const uint64_t* root_of_unity_powers,
+    const uint64_t* precon_root_of_unity_powers, uint64_t input_mod_factor = 1,
+    uint64_t output_mod_factor = 1);
 
 /// @brief Radix-4 C++ NTT implementation of the forward NTT
 /// @param[in, out] operand Input data. Overwritten with NTT output

--- a/hexl/ntt/ntt-internal.hpp
+++ b/hexl/ntt/ntt-internal.hpp
@@ -37,6 +37,19 @@ void ForwardTransformToBitReverse64(uint64_t* operand, uint64_t n,
                                     uint64_t input_mod_factor = 1,
                                     uint64_t output_mod_factor = 1);
 
+/// @brief Radix-4 C++ NTT implementation of the forward NTT
+/// @param[in, out] operand Input data. Overwritten with NTT output
+/// @param[in] n Size of the transform, i.e. the polynomial degree. Must be a
+/// power of two.
+/// @param[in] modulus Prime modulus q. Must satisfy q == 1 mod 2n
+/// @param[in] root_of_unity_powers Powers of 2n'th root of unity in F_q. In
+/// bit-reversed order
+/// @param[in] precon_root_of_unity_powers Pre-conditioned Powers of 2n'th root
+/// of unity in F_q. In bit-reversed order.
+/// @param[in] input_mod_factor Upper bound for inputs; inputs must be in [0,
+/// input_mod_factor * q)
+/// @param[in] output_mod_factor Upper bound for result; result must be in [0,
+/// output_mod_factor * q)
 void ForwardTransformToBitReverseRadix4(
     uint64_t* operand, uint64_t n, uint64_t modulus,
     const uint64_t* root_of_unity_powers,

--- a/hexl/ntt/ntt-internal.hpp
+++ b/hexl/ntt/ntt-internal.hpp
@@ -37,6 +37,12 @@ void ForwardTransformToBitReverse64(uint64_t* operand, uint64_t n,
                                     uint64_t input_mod_factor = 1,
                                     uint64_t output_mod_factor = 1);
 
+void ForwardTransformToBitReverseRadix4(
+    uint64_t* operand, uint64_t n, uint64_t modulus,
+    const uint64_t* root_of_unity_powers,
+    const uint64_t* precon_root_of_unity_powers, uint64_t input_mod_factor = 1,
+    uint64_t output_mod_factor = 1);
+
 /// @brief Reference NTT which is written for clarity rather than performance
 /// @param[in, out] operand Input data. Overwritten with NTT output
 /// @param[in] n Size of the transform, i.e. the polynomial degree. Must be a

--- a/hexl/ntt/ntt-internal.hpp
+++ b/hexl/ntt/ntt-internal.hpp
@@ -17,7 +17,7 @@
 namespace intel {
 namespace hexl {
 
-/// @brief Radix-4 C++ NTT implementation of the forward NTT
+/// @brief Radix-2 C++ NTT implementation of the forward NTT
 /// @param[in, out] operand Input data. Overwritten with NTT output
 /// @param[in] n Size of the transform, i.e. the polynomial degree. Must be a
 /// power of two.

--- a/hexl/ntt/ntt-radix-4.cpp
+++ b/hexl/ntt/ntt-radix-4.cpp
@@ -84,7 +84,6 @@ void ForwardTransformToBitReverseRadix4(
 
     for (size_t i = 0; i < m; i++) {
       HEXL_VLOG(3, "i " << i << " up to " << m);
-
       HEXL_VLOG(3, "t " << t);
 
       HEXL_LOOP_UNROLL_4
@@ -113,13 +112,21 @@ void ForwardTransformToBitReverseRadix4(
         const uint64_t W2 = root_of_unity_powers[W2_ind];
         const uint64_t W3 = root_of_unity_powers[W3_ind];
 
-        uint64_t X0 = operand[X0_ind] % modulus;
-        uint64_t X1 = operand[X1_ind] % modulus;
-        uint64_t X2 = operand[X2_ind] % modulus;
-        uint64_t X3 = operand[X3_ind] % modulus;
+        MultiplyFactor W1_factor(W1, 64, modulus);
+        MultiplyFactor W2_factor(W2, 64, modulus);
+        MultiplyFactor W3_factor(W3, 64, modulus);
 
-        FwdButterflyRadix4(&X0, &X1, &X2, &X3, W1, W2, W3, modulus,
-                           2 * modulus);
+        // uint64_t W1_precon = MultiplyFactor(W1, 64, modulus).BarrettFactor();
+        // uint64_t W2_precon = MultiplyFactor(W2, 64, modulus).BarrettFactor();
+        // uint64_t W3_precon = MultiplyFactor(W3, 64, modulus).BarrettFactor();
+
+        uint64_t X0 = operand[X0_ind];  //% modulus;
+        uint64_t X1 = operand[X1_ind];  //% modulus;
+        uint64_t X2 = operand[X2_ind];  //% modulus;
+        uint64_t X3 = operand[X3_ind];  // % modulus;
+
+        FwdButterflyRadix4(&X0, &X1, &X2, &X3, W1_factor, W2_factor, W3_factor,
+                           modulus, 2 * modulus);
 
         operand[X0_ind] = X0;
         operand[X1_ind] = X1;

--- a/hexl/ntt/ntt-radix-4.cpp
+++ b/hexl/ntt/ntt-radix-4.cpp
@@ -70,15 +70,17 @@ void ForwardTransformToBitReverseRadix4(
   HEXL_VLOG(3, "after radix 2 outputs "
                    << std::vector<uint64_t>(operand, operand + n));
 
-  uint64_t w_idx = is_power_of_4 ? 1 : 2;
-  size_t t = (n >> w_idx) >> 1;
-  for (size_t m = is_power_of_4 ? 1 : 2; m < n; m <<= 2) {
+  uint64_t m_start = is_power_of_4 ? 1 : 2;
+  size_t t = (n >> m_start) >> 1;
+
+  for (size_t m = m_start; m < n; m <<= 2) {
     HEXL_VLOG(3, "m " << m);
 
     size_t X0_offset = 0;
 
     switch (t) {
       case 4: {
+        HEXL_LOOP_UNROLL_8
         for (size_t i = 0; i < m; i++) {
           if (i != 0) {
             X0_offset += 4 * t;
@@ -116,6 +118,7 @@ void ForwardTransformToBitReverseRadix4(
         break;
       }
       case 1: {
+        HEXL_LOOP_UNROLL_8
         for (size_t i = 0; i < m; i++) {
           if (i != 0) {
             X0_offset += 4 * t;
@@ -165,7 +168,6 @@ void ForwardTransformToBitReverseRadix4(
           const uint64_t W2_precon = precon_root_of_unity_powers[W2_ind];
           const uint64_t W3_precon = precon_root_of_unity_powers[W3_ind];
 
-          HEXL_LOOP_UNROLL_8
           for (size_t j = 0; j < t; j += 16) {
             FwdButterflyRadix4(X0++, X1++, X2++, X3++, W1, W1_precon, W2,
                                W2_precon, W3, W3_precon, modulus, twice_modulus,

--- a/hexl/ntt/ntt-radix-4.cpp
+++ b/hexl/ntt/ntt-radix-4.cpp
@@ -83,10 +83,10 @@ void ForwardTransformToBitReverseRadix4(
     switch (t) {
       case 4: {
         for (size_t i = 0; i < m; i++) {
-          uint64_t X0_ind = 4 * i * t;
-          uint64_t X1_ind = X0_ind + gap;
-          uint64_t X2_ind = X0_ind + 2 * gap;
-          uint64_t X3_ind = X0_ind + 3 * gap;
+          uint64_t* X0 = operand + 16 * i;
+          uint64_t* X1 = X0 + gap;
+          uint64_t* X2 = X0 + 2 * gap;
+          uint64_t* X3 = X0 + 3 * gap;
 
           uint64_t W1_ind = m + i;
           uint64_t W2_ind = 2 * W1_ind;
@@ -99,11 +99,6 @@ void ForwardTransformToBitReverseRadix4(
           const uint64_t W1_precon = precon_root_of_unity_powers[W1_ind];
           const uint64_t W2_precon = precon_root_of_unity_powers[W2_ind];
           const uint64_t W3_precon = precon_root_of_unity_powers[W3_ind];
-
-          uint64_t* X0 = &operand[X0_ind];
-          uint64_t* X1 = &operand[X1_ind];
-          uint64_t* X2 = &operand[X2_ind];
-          uint64_t* X3 = &operand[X3_ind];
 
           FwdButterflyRadix4(X0++, X1++, X2++, X3++, W1, W1_precon, W2,
                              W2_precon, W3, W3_precon, modulus, twice_modulus,
@@ -122,7 +117,7 @@ void ForwardTransformToBitReverseRadix4(
       }
       case 1: {
         for (size_t i = 0; i < m; i++) {
-          uint64_t X0_ind = 4 * i * t;
+          uint64_t X0_ind = 4 * i;
           uint64_t X1_ind = X0_ind + gap;
           uint64_t X2_ind = X0_ind + 2 * gap;
           uint64_t X3_ind = X0_ind + 3 * gap;
@@ -150,7 +145,6 @@ void ForwardTransformToBitReverseRadix4(
         }
         break;
       }
-
       default: {
         for (size_t i = 0; i < m; i++) {
           HEXL_LOOP_UNROLL_4

--- a/hexl/ntt/ntt-radix-4.cpp
+++ b/hexl/ntt/ntt-radix-4.cpp
@@ -162,6 +162,21 @@ const uint64_t W = root_of_unity_powers[m + i];
                      << std::vector<uint64_t>(operand, operand + n));
   }
 
+  uint64_t twice_modulus = modulus * 2;
+
+  if (output_mod_factor == 1) {
+    for (size_t i = 0; i < n; ++i) {
+      if (operand[i] >= twice_modulus) {
+        operand[i] -= twice_modulus;
+      }
+      if (operand[i] >= modulus) {
+        operand[i] -= modulus;
+      }
+      HEXL_CHECK(operand[i] < modulus, "Incorrect modulus reduction in NTT "
+                                           << operand[i] << " >= " << modulus);
+    }
+  }
+
   HEXL_VLOG(3, "outputs " << std::vector<uint64_t>(operand, operand + n));
 }
 

--- a/hexl/ntt/ntt-radix-4.cpp
+++ b/hexl/ntt/ntt-radix-4.cpp
@@ -80,17 +80,8 @@ void ForwardTransformToBitReverseRadix4(
 
   uint64_t w_idx = is_power_of_4 ? 1 : 2;
   size_t t = (n >> w_idx) >> 1;
-  // for (size_t ldm = is_power_of_4 ? log_n : (log_n - 1); ldm >= 2; ldm -= 2)
-  // {
-
   for (size_t m = is_power_of_4 ? 1 : 2; m < n; m <<= 2) {
-    // size_t m = 1UL << ldm;
-    size_t m4 = m >> 2;  // 4;
-    // HEXL_VLOG(3, "ldm " << ldm);
     HEXL_VLOG(3, "m " << m);
-    HEXL_VLOG(3, "m4 " << m4);
-
-    size_t j1 = 0;
 
     size_t gap = n >> Log2(m);
     gap >>= 2;
@@ -105,14 +96,6 @@ void ForwardTransformToBitReverseRadix4(
         HEXL_VLOG(3, "j " << j << " up to " << t);
         HEXL_VLOG(3, "j1 " << j1);
 
-        // for (size_t j = 0; j < m4; j++) {
-
-        // LOG(INFO) << "r1 " << r1;
-
-        // for (size_t r = 0; r < n; r += m) {
-        // HEXL_VLOG(3, "r " << r << " up to " << n << " incrementing by " <<
-        // m);
-
         // 4-point NTT butterfly
         uint64_t X0_ind = j + 4 * i * t;
         uint64_t X1_ind = X0_ind + gap;
@@ -122,8 +105,7 @@ void ForwardTransformToBitReverseRadix4(
         HEXL_VLOG(3, "Xinds " << (std::vector<uint64_t>{X0_ind, X1_ind, X2_ind,
                                                         X3_ind}));
 
-        uint64_t W1_ind = m + i;  // * m4 + j;
-        // uint64_t W1_ind = w_idx;
+        uint64_t W1_ind = m + i;
         uint64_t W2_ind = 2 * W1_ind;
         uint64_t W3_ind = 2 * W1_ind + 1;
         ++w_idx;
@@ -134,16 +116,6 @@ void ForwardTransformToBitReverseRadix4(
         const uint64_t W1 = root_of_unity_powers[W1_ind];
         const uint64_t W2 = root_of_unity_powers[W2_ind];
         const uint64_t W3 = root_of_unity_powers[W3_ind];
-
-        // HEXL_VLOG(3, "Ws " << (std::vector<uint64_t>{W1, W2, W3}));
-
-        // HEXL_VLOG(3, "Xinds " << (std::vector<uint64_t>{X0_ind, X1_ind,
-        // X2_ind,
-        //                                                 X3_ind}));
-
-        // HEXL_VLOG(3, "Xs " << (std::vector<uint64_t>{
-        //                  operand[X0_ind], operand[X1_ind], operand[X2_ind],
-        //                  operand[X3_ind]}));
 
         uint64_t X0 = operand[X0_ind] % modulus;
         uint64_t X1 = operand[X1_ind] % modulus;
@@ -159,8 +131,6 @@ void ForwardTransformToBitReverseRadix4(
         operand[X3_ind] = X3;
       }
       w_idx = w_idx * 2;
-      j1 += (t << 2);
-
       // HEXL_VLOG(3, "inner Intermediate values "
       //                  << std::vector<uint64_t>(operand, operand + n));
     }

--- a/hexl/ntt/ntt-radix-4.cpp
+++ b/hexl/ntt/ntt-radix-4.cpp
@@ -78,6 +78,7 @@ void ForwardTransformToBitReverseRadix4(
   HEXL_VLOG(3, "after radix 2 outputs "
                    << std::vector<uint64_t>(operand, operand + n));
 
+  uint64_t w_idx = is_power_of_4 ? 0 : 1;
   for (size_t ldm = is_power_of_4 ? log_n : (log_n - 1); ldm >= 2; ldm -= 2) {
     // for (size_t ldm = 2 + size_t(!is_power_of_4); ldm <= ldn; ldm += 2) {
     size_t m = 1UL << ldm;
@@ -101,11 +102,17 @@ void ForwardTransformToBitReverseRadix4(
         uint64_t X2_ind = X0_ind + 2 * m4;
         uint64_t X3_ind = X0_ind + 3 * m4;
 
-        const uint64_t W0 = root_of_unity_powers[X0_ind];
-        const uint64_t W1 = root_of_unity_powers[X1_ind];
-        const uint64_t W2 = root_of_unity_powers[X2_ind];
-        const uint64_t W3 = root_of_unity_powers[X3_ind];
-        HEXL_VLOG(3, "Ws " << (std::vector<uint64_t>{W0, W1, W2, W3}));
+        uint64_t W1_ind = w_idx + 1;
+        uint64_t W2_ind = 2 * W1_ind;
+        uint64_t W3_ind = 2 * W1_ind + 1;
+        ++w_idx;
+
+        const uint64_t W1 = root_of_unity_powers[W1_ind];
+        const uint64_t W2 = root_of_unity_powers[W2_ind];
+        const uint64_t W3 = root_of_unity_powers[W3_ind];
+        HEXL_VLOG(3,
+                  "Winds " << (std::vector<uint64_t>{W1_ind, W2_ind, W3_ind}));
+        HEXL_VLOG(3, "Ws " << (std::vector<uint64_t>{W1, W2, W3}));
 
         HEXL_VLOG(3, "Xinds " << (std::vector<uint64_t>{X0_ind, X1_ind, X2_ind,
                                                         X3_ind}));

--- a/hexl/ntt/ntt-radix-4.cpp
+++ b/hexl/ntt/ntt-radix-4.cpp
@@ -88,32 +88,87 @@ void ForwardTransformToBitReverseRadix4(
     // std::cout << "t " << t << "\n";
 
     switch (t) {
+      case 1: {
+        for (size_t i = 0; i < m; i++) {
+          uint64_t X0_ind = 4 * i * t;
+          uint64_t X1_ind = X0_ind + gap;
+          uint64_t X2_ind = X0_ind + 2 * gap;
+          uint64_t X3_ind = X0_ind + 3 * gap;
+
+          uint64_t W1_ind = m + i;
+          uint64_t W2_ind = 2 * W1_ind;
+          uint64_t W3_ind = 2 * W1_ind + 1;
+
+          const uint64_t W1 = root_of_unity_powers[W1_ind];
+          const uint64_t W2 = root_of_unity_powers[W2_ind];
+          const uint64_t W3 = root_of_unity_powers[W3_ind];
+
+          const uint64_t W1_precon = precon_root_of_unity_powers[W1_ind];
+          const uint64_t W2_precon = precon_root_of_unity_powers[W2_ind];
+          const uint64_t W3_precon = precon_root_of_unity_powers[W3_ind];
+
+          uint64_t* X0 = &operand[X0_ind];
+          uint64_t* X1 = &operand[X1_ind];
+          uint64_t* X2 = &operand[X2_ind];
+          uint64_t* X3 = &operand[X3_ind];
+
+          FwdButterflyRadix4(X0, X1, X2, X3, W1, W1_precon, W2, W2_precon, W3,
+                             W3_precon, modulus, twice_modulus,
+                             four_times_modulus);
+        }
+        break;
+      }
+      case 4: {
+        for (size_t i = 0; i < m; i++) {
+          uint64_t X0_ind = 4 * i * t;
+          uint64_t X1_ind = X0_ind + gap;
+          uint64_t X2_ind = X0_ind + 2 * gap;
+          uint64_t X3_ind = X0_ind + 3 * gap;
+
+          uint64_t W1_ind = m + i;
+          uint64_t W2_ind = 2 * W1_ind;
+          uint64_t W3_ind = 2 * W1_ind + 1;
+
+          const uint64_t W1 = root_of_unity_powers[W1_ind];
+          const uint64_t W2 = root_of_unity_powers[W2_ind];
+          const uint64_t W3 = root_of_unity_powers[W3_ind];
+
+          const uint64_t W1_precon = precon_root_of_unity_powers[W1_ind];
+          const uint64_t W2_precon = precon_root_of_unity_powers[W2_ind];
+          const uint64_t W3_precon = precon_root_of_unity_powers[W3_ind];
+
+          uint64_t* X0 = &operand[X0_ind];
+          uint64_t* X1 = &operand[X1_ind];
+          uint64_t* X2 = &operand[X2_ind];
+          uint64_t* X3 = &operand[X3_ind];
+
+          FwdButterflyRadix4(X0++, X1++, X2++, X3++, W1, W1_precon, W2,
+                             W2_precon, W3, W3_precon, modulus, twice_modulus,
+                             four_times_modulus);
+          FwdButterflyRadix4(X0++, X1++, X2++, X3++, W1, W1_precon, W2,
+                             W2_precon, W3, W3_precon, modulus, twice_modulus,
+                             four_times_modulus);
+          FwdButterflyRadix4(X0++, X1++, X2++, X3++, W1, W1_precon, W2,
+                             W2_precon, W3, W3_precon, modulus, twice_modulus,
+                             four_times_modulus);
+          FwdButterflyRadix4(X0, X1, X2, X3, W1, W1_precon, W2, W2_precon, W3,
+                             W3_precon, modulus, twice_modulus,
+                             four_times_modulus);
+        }
+        break;
+      }
       default: {
         for (size_t i = 0; i < m; i++) {
-          HEXL_VLOG(3, "i " << i << " up to " << m);
-          HEXL_VLOG(3, "t " << t);
-
           HEXL_LOOP_UNROLL_4
           for (size_t j = 0; j < t; j++) {
-            HEXL_VLOG(3, "j " << j << " up to " << t);
-            HEXL_VLOG(3, "j1 " << j1);
-
-            // 4-point NTT butterfly
             uint64_t X0_ind = j + 4 * i * t;
             uint64_t X1_ind = X0_ind + gap;
             uint64_t X2_ind = X0_ind + 2 * gap;
             uint64_t X3_ind = X0_ind + 3 * gap;
 
-            HEXL_VLOG(3, "Xinds " << (std::vector<uint64_t>{X0_ind, X1_ind,
-                                                            X2_ind, X3_ind}));
-
             uint64_t W1_ind = m + i;
             uint64_t W2_ind = 2 * W1_ind;
             uint64_t W3_ind = 2 * W1_ind + 1;
-            ++w_idx;
-
-            HEXL_VLOG(
-                3, "Winds " << (std::vector<uint64_t>{W1_ind, W2_ind, W3_ind}));
 
             const uint64_t W1 = root_of_unity_powers[W1_ind];
             const uint64_t W2 = root_of_unity_powers[W2_ind];
@@ -122,10 +177,6 @@ void ForwardTransformToBitReverseRadix4(
             const uint64_t W1_precon = precon_root_of_unity_powers[W1_ind];
             const uint64_t W2_precon = precon_root_of_unity_powers[W2_ind];
             const uint64_t W3_precon = precon_root_of_unity_powers[W3_ind];
-
-            // MultiplyFactor W1_factor(W1, 64, modulus);
-            // MultiplyFactor W2_factor(W2, 64, modulus);
-            // MultiplyFactor W3_factor(W3, 64, modulus);
 
             uint64_t* X0 = &operand[X0_ind];
             uint64_t* X1 = &operand[X1_ind];
@@ -136,11 +187,9 @@ void ForwardTransformToBitReverseRadix4(
                                W3_precon, modulus, twice_modulus,
                                four_times_modulus);
           }
-          w_idx <<= 1;
         }
       }
     }
-
     t >>= 2;
   }
 

--- a/hexl/ntt/ntt-radix-4.cpp
+++ b/hexl/ntt/ntt-radix-4.cpp
@@ -60,7 +60,7 @@ void ForwardTransformToBitReverseRadix4(
 
     uint64_t* X = operand;
     uint64_t* Y = X + t;
-    HEXL_LOOP_UNROLL_4
+    HEXL_LOOP_UNROLL_8
     for (size_t j = 0; j < t; j++) {
       FwdButterfly(X++, Y++, W, W_precon, modulus, twice_modulus);
     }
@@ -117,10 +117,10 @@ void ForwardTransformToBitReverseRadix4(
       }
       case 1: {
         for (size_t i = 0; i < m; i++) {
-          uint64_t X0_ind = 4 * i;
-          uint64_t X1_ind = X0_ind + gap;
-          uint64_t X2_ind = X0_ind + 2 * gap;
-          uint64_t X3_ind = X0_ind + 3 * gap;
+          uint64_t* X0 = operand + 4 * i;
+          uint64_t* X1 = X0 + gap;
+          uint64_t* X2 = X0 + 2 * gap;
+          uint64_t* X3 = X0 + 3 * gap;
 
           uint64_t W1_ind = m + i;
           uint64_t W2_ind = 2 * W1_ind;
@@ -134,11 +134,6 @@ void ForwardTransformToBitReverseRadix4(
           const uint64_t W2_precon = precon_root_of_unity_powers[W2_ind];
           const uint64_t W3_precon = precon_root_of_unity_powers[W3_ind];
 
-          uint64_t* X0 = &operand[X0_ind];
-          uint64_t* X1 = &operand[X1_ind];
-          uint64_t* X2 = &operand[X2_ind];
-          uint64_t* X3 = &operand[X3_ind];
-
           FwdButterflyRadix4(X0, X1, X2, X3, W1, W1_precon, W2, W2_precon, W3,
                              W3_precon, modulus, twice_modulus,
                              four_times_modulus);
@@ -147,30 +142,25 @@ void ForwardTransformToBitReverseRadix4(
       }
       default: {
         for (size_t i = 0; i < m; i++) {
-          HEXL_LOOP_UNROLL_4
+          uint64_t* X0 = &operand[4 * i * t];
+          uint64_t* X1 = &operand[4 * i * t + gap];
+          uint64_t* X2 = &operand[4 * i * t + 2 * gap];
+          uint64_t* X3 = &operand[4 * i * t + 3 * gap];
+
+          uint64_t W1_ind = m + i;
+          uint64_t W2_ind = 2 * W1_ind;
+          uint64_t W3_ind = 2 * W1_ind + 1;
+
+          const uint64_t W1 = root_of_unity_powers[W1_ind];
+          const uint64_t W2 = root_of_unity_powers[W2_ind];
+          const uint64_t W3 = root_of_unity_powers[W3_ind];
+
+          const uint64_t W1_precon = precon_root_of_unity_powers[W1_ind];
+          const uint64_t W2_precon = precon_root_of_unity_powers[W2_ind];
+          const uint64_t W3_precon = precon_root_of_unity_powers[W3_ind];
+
+          HEXL_LOOP_UNROLL_8
           for (size_t j = 0; j < t; j += 16) {
-            uint64_t X0_ind = j + 4 * i * t;
-            uint64_t X1_ind = X0_ind + gap;
-            uint64_t X2_ind = X0_ind + 2 * gap;
-            uint64_t X3_ind = X0_ind + 3 * gap;
-
-            uint64_t W1_ind = m + i;
-            uint64_t W2_ind = 2 * W1_ind;
-            uint64_t W3_ind = 2 * W1_ind + 1;
-
-            const uint64_t W1 = root_of_unity_powers[W1_ind];
-            const uint64_t W2 = root_of_unity_powers[W2_ind];
-            const uint64_t W3 = root_of_unity_powers[W3_ind];
-
-            const uint64_t W1_precon = precon_root_of_unity_powers[W1_ind];
-            const uint64_t W2_precon = precon_root_of_unity_powers[W2_ind];
-            const uint64_t W3_precon = precon_root_of_unity_powers[W3_ind];
-
-            uint64_t* X0 = &operand[X0_ind];
-            uint64_t* X1 = &operand[X1_ind];
-            uint64_t* X2 = &operand[X2_ind];
-            uint64_t* X3 = &operand[X3_ind];
-
             FwdButterflyRadix4(X0++, X1++, X2++, X3++, W1, W1_precon, W2,
                                W2_precon, W3, W3_precon, modulus, twice_modulus,
                                four_times_modulus);

--- a/hexl/ntt/ntt-radix-4.cpp
+++ b/hexl/ntt/ntt-radix-4.cpp
@@ -80,10 +80,15 @@ void ForwardTransformToBitReverseRadix4(
     gap >>= 2;
     HEXL_VLOG(3, "gap " << gap);
 
+    size_t X0_offset = 0;
+
     switch (t) {
       case 4: {
         for (size_t i = 0; i < m; i++) {
-          uint64_t* X0 = operand + 4 * i * t;
+          if (i != 0) {
+            X0_offset += 4 * t;
+          }
+          uint64_t* X0 = operand + X0_offset;
           uint64_t* X1 = X0 + t;
           uint64_t* X2 = X0 + 2 * t;
           uint64_t* X3 = X0 + 3 * t;
@@ -117,7 +122,10 @@ void ForwardTransformToBitReverseRadix4(
       }
       case 1: {
         for (size_t i = 0; i < m; i++) {
-          uint64_t* X0 = operand + 4 * i * t;
+          if (i != 0) {
+            X0_offset += 4 * t;
+          }
+          uint64_t* X0 = operand + X0_offset;
           uint64_t* X1 = X0 + t;
           uint64_t* X2 = X0 + 2 * t;
           uint64_t* X3 = X0 + 3 * t;
@@ -142,7 +150,10 @@ void ForwardTransformToBitReverseRadix4(
       }
       default: {
         for (size_t i = 0; i < m; i++) {
-          uint64_t* X0 = operand + 4 * i * t;
+          if (i != 0) {
+            X0_offset += 4 * t;
+          }
+          uint64_t* X0 = operand + X0_offset;
           uint64_t* X1 = X0 + t;
           uint64_t* X2 = X0 + 2 * t;
           uint64_t* X3 = X0 + 3 * t;

--- a/hexl/ntt/ntt-radix-4.cpp
+++ b/hexl/ntt/ntt-radix-4.cpp
@@ -51,12 +51,6 @@ void ForwardTransformToBitReverseRadix4(
 
   bool is_power_of_4 = IsPowerOfFour(n);
 
-  LOG(INFO) << "radix 4";
-  // auto n = n;
-  // ReverseVectorBits(operand, n);
-  // HEXL_VLOG(3, "bit-reversed inputs "
-  //                  << std::vector<uint64_t>(operand, operand + n));
-
   // Radix-2 step for non-powers of 4
   if (!is_power_of_4) {
     HEXL_VLOG(3, "Radix 2 step");
@@ -69,6 +63,7 @@ void ForwardTransformToBitReverseRadix4(
 
     uint64_t* X = operand;
     uint64_t* Y = X + t;
+    HEXL_LOOP_UNROLL_4
     for (size_t j = 0; j < t; j++) {
       FwdButterfly(X++, Y++, W, W_precon, modulus, twice_modulus);
     }
@@ -92,6 +87,7 @@ void ForwardTransformToBitReverseRadix4(
 
       HEXL_VLOG(3, "t " << t);
 
+      HEXL_LOOP_UNROLL_4
       for (size_t j = 0; j < t; j++) {
         HEXL_VLOG(3, "j " << j << " up to " << t);
         HEXL_VLOG(3, "j1 " << j1);

--- a/hexl/ntt/ntt-radix-4.cpp
+++ b/hexl/ntt/ntt-radix-4.cpp
@@ -72,12 +72,13 @@ void ForwardTransformToBitReverseRadix4(
     for (size_t j = 0; j < t; j++) {
       FwdButterfly(X++, Y++, W, W_precon, modulus, twice_modulus);
     }
+    // Data in [0, 4q)
   }
 
   HEXL_VLOG(3, "after radix 2 outputs "
                    << std::vector<uint64_t>(operand, operand + n));
 
-  for (size_t ldm = log_n; ldm >= 2; ldm -= 2) {
+  for (size_t ldm = is_power_of_4 ? log_n : (log_n - 1); ldm >= 2; ldm -= 2) {
     // for (size_t ldm = 2 + size_t(!is_power_of_4); ldm <= ldn; ldm += 2) {
     size_t m = 1UL << ldm;
     size_t m4 = m >> 2;  // 4;
@@ -113,10 +114,10 @@ void ForwardTransformToBitReverseRadix4(
                          operand[X0_ind], operand[X1_ind], operand[X2_ind],
                          operand[X3_ind]}));
 
-        uint64_t X0 = operand[X0_ind];
-        uint64_t X1 = operand[X1_ind];
-        uint64_t X2 = operand[X2_ind];
-        uint64_t X3 = operand[X3_ind];
+        uint64_t X0 = operand[X0_ind] % modulus;
+        uint64_t X1 = operand[X1_ind] % modulus;
+        uint64_t X2 = operand[X2_ind] % modulus;
+        uint64_t X3 = operand[X3_ind] % modulus;
 
         FwdButterflyRadix4(&X0, &X1, &X2, &X3, W1, W2, W3, modulus,
                            2 * modulus);

--- a/hexl/ntt/ntt-radix-4.cpp
+++ b/hexl/ntt/ntt-radix-4.cpp
@@ -90,7 +90,7 @@ size_t j1 = 0;
 for (size_t i = 0; i < m; i++) {
 HEXL_VLOG(3, "i " << i);
 size_t j2 = j1 + t;
-const uint64_t W_op = root_of_unity_powers[m + i];
+const uint64_t W = root_of_unity_powers[m + i];
 */
 
   for (size_t ldm = ldn; ldm >= 2; ldm -= 2) {
@@ -100,9 +100,9 @@ const uint64_t W_op = root_of_unity_powers[m + i];
     HEXL_VLOG(3, "m " << m);
     HEXL_VLOG(3, "m4 " << m4);
 
-    // uint64_t W_op1 = 1;
-    // uint64_t W_op2 = 1;
-    // uint64_t W_op3 = 1;
+    // uint64_t W1 = 1;
+    // uint64_t W2 = 1;
+    // uint64_t W3 = 1;
     // uint64_t dw = 18;
 
     uint64_t imag = root_of_unity_powers[1];
@@ -124,12 +124,11 @@ const uint64_t W_op = root_of_unity_powers[m + i];
         uint64_t X2_ind = X0_ind + 2 * m4;
         uint64_t X3_ind = X0_ind + 3 * m4;
 
-        const uint64_t W_op0 = root_of_unity_powers[X0_ind];
-        const uint64_t W_op1 = root_of_unity_powers[X1_ind];
-        const uint64_t W_op2 = root_of_unity_powers[X2_ind];
-        const uint64_t W_op3 = root_of_unity_powers[X3_ind];
-        HEXL_VLOG(
-            3, "W_ops " << (std::vector<uint64_t>{W_op0, W_op1, W_op2, W_op3}));
+        const uint64_t W0 = root_of_unity_powers[X0_ind];
+        const uint64_t W1 = root_of_unity_powers[X1_ind];
+        const uint64_t W2 = root_of_unity_powers[X2_ind];
+        const uint64_t W3 = root_of_unity_powers[X3_ind];
+        HEXL_VLOG(3, "Ws " << (std::vector<uint64_t>{W0, W1, W2, W3}));
 
         HEXL_VLOG(3, "Xinds " << (std::vector<uint64_t>{X0_ind, X1_ind, X2_ind,
                                                         X3_ind}));
@@ -143,52 +142,21 @@ const uint64_t W_op = root_of_unity_powers[m + i];
         uint64_t X2 = operand[X2_ind];
         uint64_t X3 = operand[X3_ind];
 
-        // continue;
+        FwdButterflyRadix4(&X0, &X1, &X2, &X3, W1, W2, W3, modulus,
+                           2 * modulus);
 
-        uint64_t a0 = operand[X0_ind];
-        uint64_t a1 = MultiplyMod(operand[X1_ind], W_op1, modulus);
-        uint64_t a2 = MultiplyMod(operand[X2_ind], W_op2, modulus);
-        uint64_t a3 = MultiplyMod(operand[X3_ind], W_op3, modulus);
-
-        HEXL_VLOG(3, "as " << (std::vector<uint64_t>{a0, a1, a2, a3}));
-
-        uint64_t W1_x_x2 = MultiplyMod(W_op1, X2, modulus);
-        uint64_t tmp0 = AddUIntMod(X0, W1_x_x2, modulus);
-        uint64_t tmp2 = SubUIntMod(X0, W1_x_x2, modulus);
-        HEXL_VLOG(3, "W1_x_x2 " << W1_x_x2);
-        HEXL_VLOG(3, "tmp0 " << tmp0);
-        HEXL_VLOG(3, "tmp2 " << tmp2);
-
-        uint64_t W1_x_x3 = MultiplyMod(W_op1, X3, modulus);
-        HEXL_VLOG(3, "W1_x_x4 " << W1_x_x3);
-
-        uint64_t tmp1 = AddUIntMod(X1, W1_x_x3, modulus);
-        uint64_t tmp3 = SubUIntMod(X1, W1_x_x3, modulus);
-        HEXL_VLOG(3, "tmp1 " << tmp1);
-        HEXL_VLOG(3, "tmp3 " << tmp3);
-
-        uint64_t tmp1_x_W2 = MultiplyMod(tmp1, W_op2, modulus);
-        uint64_t Y0 = AddUIntMod(tmp0, tmp1_x_W2, modulus);
-        uint64_t Y1 = SubUIntMod(tmp0, tmp1_x_W2, modulus);
-
-        uint64_t tmp3_x_W2 = MultiplyMod(tmp3, W_op3, modulus);
-        uint64_t Y2 = AddUIntMod(tmp2, tmp3_x_W2, modulus);
-        uint64_t Y3 = SubUIntMod(tmp2, tmp3_x_W2, modulus);
-
-        HEXL_VLOG(3, "Ys " << (std::vector<uint64_t>{Y0, Y1, Y2, Y3}));
-
-        operand[X0_ind] = Y0;
-        operand[X1_ind] = Y1;
-        operand[X2_ind] = Y2;
-        operand[X3_ind] = Y3;
+        operand[X0_ind] = X0;
+        operand[X1_ind] = X1;
+        operand[X2_ind] = X2;
+        operand[X3_ind] = X3;
       }
 
       HEXL_VLOG(3, "inner Intermediate values "
                        << std::vector<uint64_t>(operand, operand + n));
 
-      // W_op1 = (W_op1 * dw) % mod;
-      // W_op2 = (W_op1 * W_op1) % mod;
-      // W_op3 = (W_op1 * W_op2) % mod;
+      // W1 = (W1 * dw) % mod;
+      // W2 = (W1 * W1) % mod;
+      // W3 = (W1 * W2) % mod;
     }
     HEXL_VLOG(3, "outer Intermediate values "
                      << std::vector<uint64_t>(operand, operand + n));

--- a/hexl/ntt/ntt-radix-4.cpp
+++ b/hexl/ntt/ntt-radix-4.cpp
@@ -72,13 +72,8 @@ void ForwardTransformToBitReverseRadix4(
 
   uint64_t w_idx = is_power_of_4 ? 1 : 2;
   size_t t = (n >> w_idx) >> 1;
-  // uint64_t gap = (n >> w_idx) >> 2;
   for (size_t m = is_power_of_4 ? 1 : 2; m < n; m <<= 2) {
     HEXL_VLOG(3, "m " << m);
-
-    size_t gap = n >> Log2(m);
-    gap >>= 2;
-    HEXL_VLOG(3, "gap " << gap);
 
     size_t X0_offset = 0;
 
@@ -225,7 +220,6 @@ void ForwardTransformToBitReverseRadix4(
       }
     }
     t >>= 2;
-    // gap <<= 2;
   }
 
   if (output_mod_factor == 1) {

--- a/hexl/ntt/ntt-radix-4.cpp
+++ b/hexl/ntt/ntt-radix-4.cpp
@@ -1,0 +1,201 @@
+// Copyright (C) 2020-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <utility>
+
+#include "hexl/logging/logging.hpp"
+#include "hexl/ntt/ntt.hpp"
+#include "hexl/number-theory/number-theory.hpp"
+#include "hexl/util/aligned-allocator.hpp"
+#include "hexl/util/check.hpp"
+#include "ntt/ntt-default.hpp"
+#include "util/cpu-features.hpp"
+
+namespace intel {
+namespace hexl {
+
+void ForwardTransformToBitReverseRadix4(
+    uint64_t* operand, uint64_t n, uint64_t modulus,
+    const uint64_t* root_of_unity_powers,
+    const uint64_t* precon_root_of_unity_powers, uint64_t input_mod_factor,
+    uint64_t output_mod_factor) {
+  HEXL_CHECK(NTT::CheckArguments(n, modulus), "");
+  HEXL_CHECK_BOUNDS(operand, n, modulus * input_mod_factor,
+                    "operand exceeds bound " << modulus * input_mod_factor);
+  HEXL_CHECK(root_of_unity_powers != nullptr,
+             "root_of_unity_powers == nullptr");
+  HEXL_CHECK(precon_root_of_unity_powers != nullptr,
+             "precon_root_of_unity_powers == nullptr");
+  HEXL_CHECK(
+      input_mod_factor == 1 || input_mod_factor == 2 || input_mod_factor == 4,
+      "input_mod_factor must be 1, 2, or 4; got " << input_mod_factor);
+  HEXL_UNUSED(input_mod_factor);
+  HEXL_CHECK(output_mod_factor == 1 || output_mod_factor == 4,
+             "output_mod_factor must be 1 or 4; got " << output_mod_factor);
+
+  HEXL_VLOG(3, "modulus " << modulus);
+  HEXL_VLOG(3, "n " << n);
+
+  HEXL_VLOG(3, "operand " << std::vector<uint64_t>(operand, operand + n));
+
+  HEXL_VLOG(3, "root_of_unity_powers " << std::vector<uint64_t>(
+                   root_of_unity_powers, root_of_unity_powers + n));
+
+  uint64_t root_of_unity = root_of_unity_powers[1];
+
+  uint64_t ldn = Log2(n);
+  HEXL_VLOG(3, "ldn " << ldn);
+
+  bool is_power_of_4 = IsPowerOfFour(n);
+
+  LOG(INFO) << "radix 4";
+  // auto n = n;
+  // ReverseVectorBits(operand, n);
+  // HEXL_VLOG(3, "bit-reversed inputs "
+  //                  << std::vector<uint64_t>(operand, operand + n));
+
+  // Radix-2 step for non-powers of 4
+  // if (!is_power_of_4) {
+  //   HEXL_VLOG(3, "Radix 2 step");
+  //   // TODO(fboemer): more efficient
+  //   for (size_t i = 0; i < n; i += 2) {
+  //     // sumdiff(f[i], f[i + 1]);
+  //     uint64_t idx1 = ReverseBitsUInt(i, ldn);
+  //     uint64_t idx2 = ReverseBitsUInt(i + 1, ldn);
+
+  //     uint64_t sum = AddUIntMod(operand[idx1], operand[idx2], modulus);
+  //     uint64_t diff = SubUIntMod(operand[idx1], operand[idx2], modulus);
+
+  //     HEXL_VLOG(3, "loaded operand[" << idx1 << "] = " << operand[idx1]);
+  //     HEXL_VLOG(3, "loaded operand[" << idx2 << "] = " << operand[idx2]);
+
+  //     operand[idx1] = sum;
+  //     operand[idx2] = diff;
+
+  //     HEXL_VLOG(3, "wrote operand[" << idx1 << "] = " << operand[idx1]);
+  //     HEXL_VLOG(3, "wrote operand[" << idx2 << "] = " << operand[idx2]);
+  //   }
+  // }
+  // HEXL_VLOG(3, "after radix 2 outputs "
+  //              << std::vector<uint64_t>(operand, operand + n));
+
+  /*
+  size_t t = (n >> 1);
+for (size_t m = 1; m < n; m <<= 1) {
+HEXL_VLOG(3, "m " << m);
+size_t j1 = 0;
+for (size_t i = 0; i < m; i++) {
+HEXL_VLOG(3, "i " << i);
+size_t j2 = j1 + t;
+const uint64_t W_op = root_of_unity_powers[m + i];
+*/
+
+  for (size_t ldm = ldn; ldm >= 2; ldm -= 2) {
+    // for (size_t ldm = 2 + size_t(!is_power_of_4); ldm <= ldn; ldm += 2) {
+    size_t m = 1UL << ldm;
+    size_t m4 = m >> 2;  // 4;
+    HEXL_VLOG(3, "m " << m);
+    HEXL_VLOG(3, "m4 " << m4);
+
+    // uint64_t W_op1 = 1;
+    // uint64_t W_op2 = 1;
+    // uint64_t W_op3 = 1;
+    // uint64_t dw = 18;
+
+    uint64_t imag = root_of_unity_powers[1];
+    HEXL_VLOG(3, "imag " << imag);
+
+    for (size_t j = 0; j < m4; j++) {
+      HEXL_VLOG(3, "j " << j);
+      // LOG(INFO) << "r1 " << r1;
+
+#pragma GCC unroll 4
+#pragma clang loop unroll_count(4)
+      for (size_t r = 0; r < n; r += m) {
+        HEXL_VLOG(3, "r " << r);
+
+        // 4-point NTT butterfly
+
+        uint64_t X0_ind = r + j;
+        uint64_t X1_ind = X0_ind + m4;
+        uint64_t X2_ind = X0_ind + 2 * m4;
+        uint64_t X3_ind = X0_ind + 3 * m4;
+
+        const uint64_t W_op0 = root_of_unity_powers[X0_ind];
+        const uint64_t W_op1 = root_of_unity_powers[X1_ind];
+        const uint64_t W_op2 = root_of_unity_powers[X2_ind];
+        const uint64_t W_op3 = root_of_unity_powers[X3_ind];
+        HEXL_VLOG(
+            3, "W_ops " << (std::vector<uint64_t>{W_op0, W_op1, W_op2, W_op3}));
+
+        HEXL_VLOG(3, "Xinds " << (std::vector<uint64_t>{X0_ind, X1_ind, X2_ind,
+                                                        X3_ind}));
+
+        HEXL_VLOG(3, "Xs " << (std::vector<uint64_t>{
+                         operand[X0_ind], operand[X1_ind], operand[X2_ind],
+                         operand[X3_ind]}));
+
+        uint64_t X0 = operand[X0_ind];
+        uint64_t X1 = operand[X1_ind];
+        uint64_t X2 = operand[X2_ind];
+        uint64_t X3 = operand[X3_ind];
+
+        // continue;
+
+        uint64_t a0 = operand[X0_ind];
+        uint64_t a1 = MultiplyMod(operand[X1_ind], W_op1, modulus);
+        uint64_t a2 = MultiplyMod(operand[X2_ind], W_op2, modulus);
+        uint64_t a3 = MultiplyMod(operand[X3_ind], W_op3, modulus);
+
+        HEXL_VLOG(3, "as " << (std::vector<uint64_t>{a0, a1, a2, a3}));
+
+        uint64_t W1_x_x2 = MultiplyMod(W_op1, X2, modulus);
+        uint64_t tmp0 = AddUIntMod(X0, W1_x_x2, modulus);
+        uint64_t tmp2 = SubUIntMod(X0, W1_x_x2, modulus);
+        HEXL_VLOG(3, "W1_x_x2 " << W1_x_x2);
+        HEXL_VLOG(3, "tmp0 " << tmp0);
+        HEXL_VLOG(3, "tmp2 " << tmp2);
+
+        uint64_t W1_x_x3 = MultiplyMod(W_op1, X3, modulus);
+        HEXL_VLOG(3, "W1_x_x4 " << W1_x_x3);
+
+        uint64_t tmp1 = AddUIntMod(X1, W1_x_x3, modulus);
+        uint64_t tmp3 = SubUIntMod(X1, W1_x_x3, modulus);
+        HEXL_VLOG(3, "tmp1 " << tmp1);
+        HEXL_VLOG(3, "tmp3 " << tmp3);
+
+        uint64_t tmp1_x_W2 = MultiplyMod(tmp1, W_op2, modulus);
+        uint64_t Y0 = AddUIntMod(tmp0, tmp1_x_W2, modulus);
+        uint64_t Y1 = SubUIntMod(tmp0, tmp1_x_W2, modulus);
+
+        uint64_t tmp3_x_W2 = MultiplyMod(tmp3, W_op3, modulus);
+        uint64_t Y2 = AddUIntMod(tmp2, tmp3_x_W2, modulus);
+        uint64_t Y3 = SubUIntMod(tmp2, tmp3_x_W2, modulus);
+
+        HEXL_VLOG(3, "Ys " << (std::vector<uint64_t>{Y0, Y1, Y2, Y3}));
+
+        operand[X0_ind] = Y0;
+        operand[X1_ind] = Y1;
+        operand[X2_ind] = Y2;
+        operand[X3_ind] = Y3;
+      }
+
+      HEXL_VLOG(3, "inner Intermediate values "
+                       << std::vector<uint64_t>(operand, operand + n));
+
+      // W_op1 = (W_op1 * dw) % mod;
+      // W_op2 = (W_op1 * W_op1) % mod;
+      // W_op3 = (W_op1 * W_op2) % mod;
+    }
+    HEXL_VLOG(3, "outer Intermediate values "
+                     << std::vector<uint64_t>(operand, operand + n));
+  }
+
+  HEXL_VLOG(3, "outputs " << std::vector<uint64_t>(operand, operand + n));
+}
+
+}  // namespace hexl
+}  // namespace intel

--- a/hexl/ntt/ntt-radix-4.cpp
+++ b/hexl/ntt/ntt-radix-4.cpp
@@ -83,10 +83,10 @@ void ForwardTransformToBitReverseRadix4(
     switch (t) {
       case 4: {
         for (size_t i = 0; i < m; i++) {
-          uint64_t* X0 = operand + 16 * i;
-          uint64_t* X1 = X0 + gap;
-          uint64_t* X2 = X0 + 2 * gap;
-          uint64_t* X3 = X0 + 3 * gap;
+          uint64_t* X0 = operand + 4 * i * t;
+          uint64_t* X1 = X0 + t;
+          uint64_t* X2 = X0 + 2 * t;
+          uint64_t* X3 = X0 + 3 * t;
 
           uint64_t W1_ind = m + i;
           uint64_t W2_ind = 2 * W1_ind;
@@ -117,10 +117,10 @@ void ForwardTransformToBitReverseRadix4(
       }
       case 1: {
         for (size_t i = 0; i < m; i++) {
-          uint64_t* X0 = operand + 4 * i;
-          uint64_t* X1 = X0 + gap;
-          uint64_t* X2 = X0 + 2 * gap;
-          uint64_t* X3 = X0 + 3 * gap;
+          uint64_t* X0 = operand + 4 * i * t;
+          uint64_t* X1 = X0 + t;
+          uint64_t* X2 = X0 + 2 * t;
+          uint64_t* X3 = X0 + 3 * t;
 
           uint64_t W1_ind = m + i;
           uint64_t W2_ind = 2 * W1_ind;
@@ -142,10 +142,10 @@ void ForwardTransformToBitReverseRadix4(
       }
       default: {
         for (size_t i = 0; i < m; i++) {
-          uint64_t* X0 = &operand[4 * i * t];
-          uint64_t* X1 = &operand[4 * i * t + gap];
-          uint64_t* X2 = &operand[4 * i * t + 2 * gap];
-          uint64_t* X3 = &operand[4 * i * t + 3 * gap];
+          uint64_t* X0 = operand + 4 * i * t;
+          uint64_t* X1 = X0 + t;
+          uint64_t* X2 = X0 + 2 * t;
+          uint64_t* X3 = X0 + 3 * t;
 
           uint64_t W1_ind = m + i;
           uint64_t W2_ind = 2 * W1_ind;

--- a/test/test-ntt-avx512.cpp
+++ b/test/test-ntt-avx512.cpp
@@ -310,16 +310,10 @@ TEST(NTT, FwdNTT_AVX512_64) {
         input[i] = distrib(gen);
       }
       std::vector<std::uint64_t> input_avx = input;
-      std::vector<std::uint64_t> input_radix_4 = input;
       std::vector<std::uint64_t> input_avx_lazy = input;
 
       ForwardTransformToBitReverse64(
           input.data(), N, modulus, ntt.GetRootOfUnityPowers().data(),
-          ntt.GetPrecon64RootOfUnityPowers().data(), 2, 1);
-
-      // Radix 4
-      ForwardTransformToBitReverseRadix4(
-          input_radix_4.data(), N, modulus, ntt.GetRootOfUnityPowers().data(),
           ntt.GetPrecon64RootOfUnityPowers().data(), 2, 1);
 
       ForwardTransformToBitReverseAVX512<64>(
@@ -337,7 +331,6 @@ TEST(NTT, FwdNTT_AVX512_64) {
       }
 
       ASSERT_EQ(input, input_avx);
-      ASSERT_EQ(input, input_radix_4);
       ASSERT_EQ(input, input_avx_lazy);
     }
   }

--- a/test/test-ntt-avx512.cpp
+++ b/test/test-ntt-avx512.cpp
@@ -260,7 +260,7 @@ TEST(NTT, FwdNTT_AVX512_32) {
       std::vector<std::uint64_t> input_avx = input;
       std::vector<std::uint64_t> input_avx_lazy = input;
 
-      ForwardTransformToBitReverse64(
+      ForwardTransformToBitReverseRadix2(
           input.data(), N, modulus, ntt.GetRootOfUnityPowers().data(),
           ntt.GetPrecon64RootOfUnityPowers().data(), 2, 1);
 
@@ -312,7 +312,7 @@ TEST(NTT, FwdNTT_AVX512_64) {
       std::vector<std::uint64_t> input_avx = input;
       std::vector<std::uint64_t> input_avx_lazy = input;
 
-      ForwardTransformToBitReverse64(
+      ForwardTransformToBitReverseRadix2(
           input.data(), N, modulus, ntt.GetRootOfUnityPowers().data(),
           ntt.GetPrecon64RootOfUnityPowers().data(), 2, 1);
 

--- a/test/test-ntt-avx512.cpp
+++ b/test/test-ntt-avx512.cpp
@@ -310,10 +310,16 @@ TEST(NTT, FwdNTT_AVX512_64) {
         input[i] = distrib(gen);
       }
       std::vector<std::uint64_t> input_avx = input;
+      std::vector<std::uint64_t> input_radix_4 = input;
       std::vector<std::uint64_t> input_avx_lazy = input;
 
       ForwardTransformToBitReverse64(
           input.data(), N, modulus, ntt.GetRootOfUnityPowers().data(),
+          ntt.GetPrecon64RootOfUnityPowers().data(), 2, 1);
+
+      // Radix 4
+      ForwardTransformToBitReverseRadix4(
+          input_radix_4.data(), N, modulus, ntt.GetRootOfUnityPowers().data(),
           ntt.GetPrecon64RootOfUnityPowers().data(), 2, 1);
 
       ForwardTransformToBitReverseAVX512<64>(
@@ -331,6 +337,7 @@ TEST(NTT, FwdNTT_AVX512_64) {
       }
 
       ASSERT_EQ(input, input_avx);
+      ASSERT_EQ(input, input_radix_4);
       ASSERT_EQ(input, input_avx_lazy);
     }
   }

--- a/test/test-ntt.cpp
+++ b/test/test-ntt.cpp
@@ -256,44 +256,44 @@ TEST_P(NTTTest, API) {
   AssertEqual(input, exp_output);
 
   // In-place lazy NTT
-  // input = input_copy;
-  // ntt.ComputeForward(input.data(), input.data(), 2, 4);
-  // for (auto& elem : input) {
-  //   elem = elem % modulus;
-  // }
-  // // AssertEqual(input, exp_output);
-
-  // // Compute reference
-  // input = input_copy;
-  // ReferenceForwardTransformToBitReverse(input.data(), N, modulus,
-  //                                       ntt.GetRootOfUnityPowers().data());
+  input = input_copy;
+  ntt.ComputeForward(input.data(), input.data(), 2, 4);
+  for (auto& elem : input) {
+    elem = elem % modulus;
+  }
   // AssertEqual(input, exp_output);
 
-  // // Test round-trip
-  // input = input_copy;
-  // ntt.ComputeForward(out_buffer.data(), input.data(), 1, 1);
-  // ntt.ComputeInverse(input.data(), out_buffer.data(), 1, 1);
-  // AssertEqual(input, input_copy);
+  // Compute reference
+  input = input_copy;
+  ReferenceForwardTransformToBitReverse(input.data(), N, modulus,
+                                        ntt.GetRootOfUnityPowers().data());
+  AssertEqual(input, exp_output);
 
-  // // Test out-of-place forward
-  // input = input_copy;
-  // ntt.ComputeForward(out_buffer.data(), input.data(), 2, 1);
-  // AssertEqual(out_buffer, exp_output);
+  // Test round-trip
+  input = input_copy;
+  ntt.ComputeForward(out_buffer.data(), input.data(), 1, 1);
+  ntt.ComputeInverse(input.data(), out_buffer.data(), 1, 1);
+  AssertEqual(input, input_copy);
 
-  // // Test out-of-place inverse
-  // input = input_copy;
-  // ntt.ComputeForward(out_buffer.data(), input.data(), 2, 1);
-  // ntt.ComputeInverse(input.data(), out_buffer.data(), 1, 1);
-  // AssertEqual(input, input_copy);
+  // Test out-of-place forward
+  input = input_copy;
+  ntt.ComputeForward(out_buffer.data(), input.data(), 2, 1);
+  AssertEqual(out_buffer, exp_output);
 
-  // // Test out-of-place inverse lazy
-  // input = input_copy;
-  // ntt.ComputeForward(out_buffer.data(), input.data(), 2, 1);
-  // ntt.ComputeInverse(input.data(), out_buffer.data(), 1, 2);
-  // for (auto& elem : input) {
-  //   elem = elem % modulus;
-  // }
-  // AssertEqual(input, input_copy);
+  // Test out-of-place inverse
+  input = input_copy;
+  ntt.ComputeForward(out_buffer.data(), input.data(), 2, 1);
+  ntt.ComputeInverse(input.data(), out_buffer.data(), 1, 1);
+  AssertEqual(input, input_copy);
+
+  // Test out-of-place inverse lazy
+  input = input_copy;
+  ntt.ComputeForward(out_buffer.data(), input.data(), 2, 1);
+  ntt.ComputeInverse(input.data(), out_buffer.data(), 1, 2);
+  for (auto& elem : input) {
+    elem = elem % modulus;
+  }
+  AssertEqual(input, input_copy);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/test-ntt.cpp
+++ b/test/test-ntt.cpp
@@ -240,7 +240,7 @@ class NTTTest
  public:
 };
 
-// Test different parts of the API
+// Test different parts of the public API
 TEST_P(NTTTest, API) {
   uint64_t N = std::get<0>(GetParam());
   uint64_t modulus = std::get<1>(GetParam());
@@ -261,7 +261,7 @@ TEST_P(NTTTest, API) {
   for (auto& elem : input) {
     elem = elem % modulus;
   }
-  // AssertEqual(input, exp_output);
+  AssertEqual(input, exp_output);
 
   // Compute reference
   input = input_copy;
@@ -297,7 +297,7 @@ TEST_P(NTTTest, API) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    NTTTest, NTTTest,
+    NTT, NTTTest,
     ::testing::Values(
         std::make_tuple(2, 281474976710897, std::vector<uint64_t>{0, 0},
                         std::vector<uint64_t>{0, 0}),
@@ -370,7 +370,7 @@ TEST_P(FwdNTTZerosTest, Zeros) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    FwdNTTZerosTest, FwdNTTZerosTest,
+    NTT, FwdNTTZerosTest,
     ::testing::Values(
         std::make_tuple(1 << 1, 30), std::make_tuple(1 << 2, 30),
         std::make_tuple(1 << 3, 30), std::make_tuple(1 << 4, 35),
@@ -407,7 +407,56 @@ TEST_P(InvNTTZerosTest, Zeros) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    InvNTTZerosTest, InvNTTZerosTest,
+    NTT, InvNTTZerosTest,
+    ::testing::Values(
+        std::make_tuple(1 << 1, 30), std::make_tuple(1 << 2, 30),
+        std::make_tuple(1 << 3, 30), std::make_tuple(1 << 4, 35),
+        std::make_tuple(1 << 5, 35), std::make_tuple(1 << 6, 35),
+        std::make_tuple(1 << 7, 40), std::make_tuple(1 << 8, 40),
+        std::make_tuple(1 << 9, 40), std::make_tuple(1 << 10, 45),
+        std::make_tuple(1 << 11, 45), std::make_tuple(1 << 12, 45),
+        std::make_tuple(1 << 13, 50), std::make_tuple(1 << 14, 50),
+        std::make_tuple(1 << 15, 50), std::make_tuple(1 << 16, 55),
+        std::make_tuple(1 << 17, 55)));
+
+class ForwardRadix4Test
+    : public ::testing::TestWithParam<std::tuple<uint64_t, uint64_t>> {
+ protected:
+  void SetUp() {}
+  void TearDown() {}
+
+ public:
+};
+
+TEST_P(ForwardRadix4Test, Random) {
+  uint64_t N = std::get<0>(GetParam());
+  uint64_t modulus_bits = std::get<1>(GetParam());
+  uint64_t modulus = GeneratePrimes(1, modulus_bits, N)[0];
+
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<uint64_t> distrib(1, modulus - 1);
+
+  std::vector<uint64_t> input(N);
+  for (size_t i = 0; i < N; ++i) {
+    input[i] = distrib(gen);
+  }
+
+  NTT ntt(N, modulus);
+
+  auto input_radix4 = input;
+  ForwardTransformToBitReverseRadix4(
+      input_radix4.data(), N, modulus, ntt.GetRootOfUnityPowers().data(),
+      ntt.GetPrecon64RootOfUnityPowers().data(), 2, 1);
+
+  ReferenceForwardTransformToBitReverse(input.data(), N, modulus,
+                                        ntt.GetRootOfUnityPowers().data());
+
+  AssertEqual(input, input_radix4);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    NTT, ForwardRadix4Test,
     ::testing::Values(
         std::make_tuple(1 << 1, 30), std::make_tuple(1 << 2, 30),
         std::make_tuple(1 << 3, 30), std::make_tuple(1 << 4, 35),

--- a/test/test-ntt.cpp
+++ b/test/test-ntt.cpp
@@ -256,44 +256,44 @@ TEST_P(NTTTest, API) {
   AssertEqual(input, exp_output);
 
   // In-place lazy NTT
-  input = input_copy;
-  ntt.ComputeForward(input.data(), input.data(), 2, 4);
-  for (auto& elem : input) {
-    elem = elem % modulus;
-  }
-  AssertEqual(input, exp_output);
+  // input = input_copy;
+  // ntt.ComputeForward(input.data(), input.data(), 2, 4);
+  // for (auto& elem : input) {
+  //   elem = elem % modulus;
+  // }
+  // // AssertEqual(input, exp_output);
 
-  // Compute reference
-  input = input_copy;
-  ReferenceForwardTransformToBitReverse(input.data(), N, modulus,
-                                        ntt.GetRootOfUnityPowers().data());
-  AssertEqual(input, exp_output);
+  // // Compute reference
+  // input = input_copy;
+  // ReferenceForwardTransformToBitReverse(input.data(), N, modulus,
+  //                                       ntt.GetRootOfUnityPowers().data());
+  // AssertEqual(input, exp_output);
 
-  // Test round-trip
-  input = input_copy;
-  ntt.ComputeForward(out_buffer.data(), input.data(), 1, 1);
-  ntt.ComputeInverse(input.data(), out_buffer.data(), 1, 1);
-  AssertEqual(input, input_copy);
+  // // Test round-trip
+  // input = input_copy;
+  // ntt.ComputeForward(out_buffer.data(), input.data(), 1, 1);
+  // ntt.ComputeInverse(input.data(), out_buffer.data(), 1, 1);
+  // AssertEqual(input, input_copy);
 
-  // Test out-of-place forward
-  input = input_copy;
-  ntt.ComputeForward(out_buffer.data(), input.data(), 2, 1);
-  AssertEqual(out_buffer, exp_output);
+  // // Test out-of-place forward
+  // input = input_copy;
+  // ntt.ComputeForward(out_buffer.data(), input.data(), 2, 1);
+  // AssertEqual(out_buffer, exp_output);
 
-  // Test out-of-place inverse
-  input = input_copy;
-  ntt.ComputeForward(out_buffer.data(), input.data(), 2, 1);
-  ntt.ComputeInverse(input.data(), out_buffer.data(), 1, 1);
-  AssertEqual(input, input_copy);
+  // // Test out-of-place inverse
+  // input = input_copy;
+  // ntt.ComputeForward(out_buffer.data(), input.data(), 2, 1);
+  // ntt.ComputeInverse(input.data(), out_buffer.data(), 1, 1);
+  // AssertEqual(input, input_copy);
 
-  // Test out-of-place inverse lazy
-  input = input_copy;
-  ntt.ComputeForward(out_buffer.data(), input.data(), 2, 1);
-  ntt.ComputeInverse(input.data(), out_buffer.data(), 1, 2);
-  for (auto& elem : input) {
-    elem = elem % modulus;
-  }
-  AssertEqual(input, input_copy);
+  // // Test out-of-place inverse lazy
+  // input = input_copy;
+  // ntt.ComputeForward(out_buffer.data(), input.data(), 2, 1);
+  // ntt.ComputeInverse(input.data(), out_buffer.data(), 1, 2);
+  // for (auto& elem : input) {
+  //   elem = elem % modulus;
+  // }
+  // AssertEqual(input, input_copy);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/test-number-theory.cpp
+++ b/test/test-number-theory.cpp
@@ -131,6 +131,21 @@ TEST(NumberTheory, IsPowerOfTwo) {
   }
 }
 
+TEST(NumberTheory, IsPowerOfFour) {
+  std::vector<uint64_t> powers_of_four{1,    4,    16,    64,   256,
+                                       1024, 4096, 16384, 65536};
+  std::vector<uint64_t> not_powers_of_four{0, 2,  3,  5,  7,    8,
+                                           9, 31, 32, 33, 1025, 4095};
+
+  for (auto power_of_four : powers_of_four) {
+    EXPECT_TRUE(IsPowerOfFour(power_of_four));
+  }
+
+  for (auto not_power_of_four : not_powers_of_four) {
+    EXPECT_FALSE(IsPowerOfFour(not_power_of_four));
+  }
+}
+
 TEST(NumberTheory, IsPrimitiveRoot) {
   uint64_t modulus = 11;
   ASSERT_TRUE(IsPrimitiveRoot(10, 2, modulus));


### PR DESCRIPTION
Initial native C++ implementation of the radix-4 forward NTT (see https://jiratest.idoc.intel.com/browse/GLADE-19)
Renames `ForwardTransformToBitReverse64` to `ForwardTransformToBitReverseRadix2`

Initial performance is ~1.07x the runtime of the radix-2 NTT 


```
----------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations
----------------------------------------------------------------------
BM_FwdNTTNativeRadix2/1024        6.21 us         6.20 us       113086
BM_FwdNTTNativeRadix2/4096        28.9 us         28.9 us        24272
BM_FwdNTTNativeRadix2/16384        137 us          136 us         5135
BM_FwdNTTNativeRadix4/1024        6.68 us         6.67 us       104802
BM_FwdNTTNativeRadix4/4096        31.5 us         31.5 us        22241
BM_FwdNTTNativeRadix4/16384        146 us          146 us         4816
```