### PR TITLE
Fboemer/ntt fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,12 @@
 
 ## Version 1.2.1
 - Fixes a bug in AVX512 floating-point implementation of element-wise vector-vector modular multiplication (https://github.com/microsoft/SEAL/issues/385)
-- Fixes a bug in the NTT default allocator (https://gitlab.com/palisade/palisade-development/-/issues/323#note_662270512)
+- Fixes a bug in the NTT default constructor (https://gitlab.com/palisade/palisade-development/-/issues/329)
+- Fixes a bug in the AVX512 NTT (https://github.com/intel/hexl/pull/58)
 - Improves performance of EltwiseFMAModAVX512 on ICX (https://github.com/intel/hexl/pull/42)
 - Improves performance of the native NTT
 - Adds reference implementations for the radix-4 NTT
+- Enables support for pre-built easylogging (https://github.com/intel/hexl/pull/57)
 
 ## Version 1.2.0
 - Large performance improvement in large (N >= 16384) AVX512 NTTs via recursive implementations

--- a/benchmark/bench-eltwise-fma-mod.cpp
+++ b/benchmark/bench-eltwise-fma-mod.cpp
@@ -35,7 +35,7 @@ static void BM_EltwiseFMAModAddNative(benchmark::State& state) {  //  NOLINT
 
 BENCHMARK(BM_EltwiseFMAModAddNative)
     ->Unit(benchmark::kMicrosecond)
-    ->ArgsProduct({{1024, 8192, 16384}, {false, true}});
+    ->ArgsProduct({{1024, 4096, 16384}, {false, true}});
 
 //=================================================================
 
@@ -59,7 +59,7 @@ static void BM_EltwiseFMAModAVX512DQ(benchmark::State& state) {  //  NOLINT
 
 BENCHMARK(BM_EltwiseFMAModAVX512DQ)
     ->Unit(benchmark::kMicrosecond)
-    ->ArgsProduct({{1024, 8192, 16384}, {false, true}});
+    ->ArgsProduct({{1024, 4096, 16384}, {false, true}});
 #endif
 
 //=================================================================
@@ -84,7 +84,7 @@ static void BM_EltwiseFMAModAVX512IFMA(benchmark::State& state) {  //  NOLINT
 
 BENCHMARK(BM_EltwiseFMAModAVX512IFMA)
     ->Unit(benchmark::kMicrosecond)
-    ->ArgsProduct({{1024, 8192, 16384}, {false, true}});
+    ->ArgsProduct({{1024, 4096, 16384}, {false, true}});
 
 #endif
 

--- a/benchmark/bench-eltwise-mult-mod.cpp
+++ b/benchmark/bench-eltwise-mult-mod.cpp
@@ -36,7 +36,7 @@ static void BM_EltwiseMultMod(benchmark::State& state) {  //  NOLINT
 
 BENCHMARK(BM_EltwiseMultMod)
     ->Unit(benchmark::kMicrosecond)
-    ->ArgsProduct({{1024, 8192, 16384}, {48, 60}, {1, 2, 4}});
+    ->ArgsProduct({{1024, 4096, 16384}, {48, 60}, {1, 2, 4}});
 
 //=================================================================
 

--- a/benchmark/bench-ntt.cpp
+++ b/benchmark/bench-ntt.cpp
@@ -284,7 +284,7 @@ BENCHMARK(BM_InvNTTNativeRadix2)
 
 static void BM_InvNTTNativeRadix4(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
-  size_t modulus = GeneratePrimes(1, 45, ntt_size)[0];
+  size_t modulus = GeneratePrimes(1, 45, true, ntt_size)[0];
 
   AlignedVector64<uint64_t> input(ntt_size, 1);
   NTT ntt(ntt_size, modulus);

--- a/benchmark/bench-ntt.cpp
+++ b/benchmark/bench-ntt.cpp
@@ -22,7 +22,7 @@ namespace hexl {
 
 static void BM_FwdNTTNativeRadix2(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
-  size_t modulus = GeneratePrimes(1, 45, ntt_size)[0];
+  size_t modulus = GeneratePrimes(1, 45, true, ntt_size)[0];
 
   AlignedVector64<uint64_t> input(ntt_size, 1);
   NTT ntt(ntt_size, modulus);
@@ -43,7 +43,7 @@ BENCHMARK(BM_FwdNTTNativeRadix2)
 
 static void BM_FwdNTTNativeRadix4(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
-  size_t modulus = GeneratePrimes(1, 45, ntt_size)[0];
+  size_t modulus = GeneratePrimes(1, 45, true, ntt_size)[0];
 
   AlignedVector64<uint64_t> input(ntt_size, 1);
   NTT ntt(ntt_size, modulus);
@@ -67,7 +67,7 @@ BENCHMARK(BM_FwdNTTNativeRadix4)
 static void BM_FwdNTT_AVX512IFMA(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
   size_t modulus_bits = 49;
-  size_t modulus = GeneratePrimes(1, modulus_bits, ntt_size)[0];
+  size_t modulus = GeneratePrimes(1, modulus_bits, true, ntt_size)[0];
 
   AlignedVector64<uint64_t> input(ntt_size, 1);
   NTT ntt(ntt_size, modulus);
@@ -96,7 +96,7 @@ BENCHMARK(BM_FwdNTT_AVX512IFMA)
 static void BM_FwdNTT_AVX512IFMALazy(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
   size_t modulus_bits = 49;
-  size_t modulus = GeneratePrimes(1, modulus_bits, ntt_size)[0];
+  size_t modulus = GeneratePrimes(1, modulus_bits, true, ntt_size)[0];
 
   AlignedVector64<uint64_t> input(ntt_size, 1);
   NTT ntt(ntt_size, modulus);
@@ -132,7 +132,7 @@ static void BM_FwdNTT_AVX512DQ_32(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
   uint64_t output_mod_factor = state.range(1);
   size_t modulus_bits = 29;
-  size_t modulus = GeneratePrimes(1, modulus_bits, ntt_size)[0];
+  size_t modulus = GeneratePrimes(1, modulus_bits, true, ntt_size)[0];
 
   AlignedVector64<uint64_t> input(ntt_size, 1);
   NTT ntt(ntt_size, modulus);
@@ -163,7 +163,7 @@ static void BM_FwdNTT_AVX512DQ_64(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
   uint64_t output_mod_factor = state.range(1);
   size_t modulus_bits = 55;
-  size_t modulus = GeneratePrimes(1, modulus_bits, ntt_size)[0];
+  size_t modulus = GeneratePrimes(1, modulus_bits, true, ntt_size)[0];
 
   AlignedVector64<uint64_t> input(ntt_size, 1);
   NTT ntt(ntt_size, modulus);
@@ -195,7 +195,7 @@ BENCHMARK(BM_FwdNTT_AVX512DQ_64)
 // state[0] is the degree
 static void BM_FwdNTTInPlace(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
-  size_t modulus = GeneratePrimes(1, 61, ntt_size)[0];
+  size_t modulus = GeneratePrimes(1, 61, true, ntt_size)[0];
 
   AlignedVector64<uint64_t> input(ntt_size, 1);
   NTT ntt(ntt_size, modulus);
@@ -216,7 +216,7 @@ BENCHMARK(BM_FwdNTTInPlace)
 // state[0] is the degree
 static void BM_FwdNTTCopy(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
-  size_t modulus = GeneratePrimes(1, 45, ntt_size)[0];
+  size_t modulus = GeneratePrimes(1, 45, true, ntt_size)[0];
 
   AlignedVector64<uint64_t> input(ntt_size, 1);
   AlignedVector64<uint64_t> output(ntt_size, 1);
@@ -236,7 +236,7 @@ BENCHMARK(BM_FwdNTTCopy)
 // state[0] is the degree
 static void BM_InvNTTCopy(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
-  size_t modulus = GeneratePrimes(1, 45, ntt_size)[0];
+  size_t modulus = GeneratePrimes(1, 45, true, ntt_size)[0];
 
   AlignedVector64<uint64_t> input(ntt_size, 1);
   AlignedVector64<uint64_t> output(ntt_size, 1);
@@ -259,7 +259,7 @@ BENCHMARK(BM_InvNTTCopy)
 
 static void BM_InvNTTNativeRadix2(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
-  size_t modulus = GeneratePrimes(1, 45, ntt_size)[0];
+  size_t modulus = GeneratePrimes(1, 45, true, ntt_size)[0];
 
   AlignedVector64<uint64_t> input(ntt_size, 1);
   NTT ntt(ntt_size, modulus);
@@ -311,7 +311,7 @@ BENCHMARK(BM_InvNTTNativeRadix4)
 // state[0] is the degree
 static void BM_InvNTT_AVX512IFMA(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
-  size_t modulus = GeneratePrimes(1, 49, ntt_size)[0];
+  size_t modulus = GeneratePrimes(1, 49, true, ntt_size)[0];
 
   AlignedVector64<uint64_t> input(ntt_size, 1);
   NTT ntt(ntt_size, modulus);
@@ -337,7 +337,7 @@ BENCHMARK(BM_InvNTT_AVX512IFMA)
 // state[0] is the degree
 static void BM_InvNTT_AVX512IFMALazy(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
-  size_t modulus = GeneratePrimes(1, 49, ntt_size)[0];
+  size_t modulus = GeneratePrimes(1, 49, true, ntt_size)[0];
 
   AlignedVector64<uint64_t> input(ntt_size, 1);
   NTT ntt(ntt_size, modulus);
@@ -367,7 +367,7 @@ BENCHMARK(BM_InvNTT_AVX512IFMALazy)
 static void BM_InvNTT_AVX512DQ_32(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
   uint64_t output_mod_factor = state.range(1);
-  size_t modulus = GeneratePrimes(1, 30, ntt_size)[0];
+  size_t modulus = GeneratePrimes(1, 30, true, ntt_size)[0];
 
   AlignedVector64<uint64_t> input(ntt_size, 1);
   NTT ntt(ntt_size, modulus);
@@ -395,7 +395,7 @@ BENCHMARK(BM_InvNTT_AVX512DQ_32)
 static void BM_InvNTT_AVX512DQ_64(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
   uint64_t output_mod_factor = state.range(1);
-  size_t modulus = GeneratePrimes(1, 61, ntt_size)[0];
+  size_t modulus = GeneratePrimes(1, 61, true, ntt_size)[0];
 
   AlignedVector64<uint64_t> input(ntt_size, 1);
   NTT ntt(ntt_size, modulus);

--- a/hexl/CMakeLists.txt
+++ b/hexl/CMakeLists.txt
@@ -76,6 +76,8 @@ endif()
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     target_compile_options(hexl PRIVATE -Wall -Wconversion -Wshadow -pedantic -Wextra
         -Wno-unknown-pragmas -march=native -O3 -fomit-frame-pointer
+        -Wno-sign-conversion
+        -Wno-implicit-int-conversion
     )
     # Avoid 3rd-party dependency warnings when including HEXL as a dependency
     target_compile_options(hexl PUBLIC

--- a/hexl/include/hexl/number-theory/number-theory.hpp
+++ b/hexl/include/hexl/number-theory/number-theory.hpp
@@ -176,14 +176,17 @@ inline unsigned char AddUInt64(uint64_t operand1, uint64_t operand2,
 /// @brief Returns whether or not the input is prime
 bool IsPrime(uint64_t n);
 
-/// @brief Generates a list of num_primes primes in the range [2^(bit_size,
+/// @brief Generates a list of num_primes primes in the range [2^(bit_size),
 // 2^(bit_size+1)]. Ensures each prime q satisfies
 // q % (2*ntt_size+1)) == 1
 /// @param[in] num_primes Number of primes to generate
 /// @param[in] bit_size Bit size of each prime
+/// @param[in] prefer_small_primes When true, returns primes starting from
+/// 2^(bit_size); when false, returns primes starting from 2^(bit_size+1)
 /// @param[in] ntt_size N such that each prime q satisfies q % (2N) == 1. N must
-/// be a power of two
+/// be a power of two less than 2^bit_size.
 std::vector<uint64_t> GeneratePrimes(size_t num_primes, size_t bit_size,
+                                     bool prefer_small_primes,
                                      size_t ntt_size = 1);
 
 /// @brief Returns input mod modulus, computed via 64-bit Barrett reduction

--- a/hexl/ntt/fwd-ntt-avx512.cpp
+++ b/hexl/ntt/fwd-ntt-avx512.cpp
@@ -61,15 +61,6 @@ template void ForwardTransformToBitReverseAVX512<NTT::s_default_shift_bits>(
 template <int BitShift, bool InputLessThanMod>
 void FwdButterfly(__m512i* X, __m512i* Y, __m512i W, __m512i W_precon,
                   __m512i neg_modulus, __m512i twice_modulus) {
-  HEXL_CHECK_BOUNDS(ExtractValues(*Y).data(), 8,
-                    2 * ExtractValues(twice_modulus).data()[0],
-                    "FwdButterfly input Y exceeds 4 * modulus "
-                        << 2 * ExtractValues(twice_modulus).data()[0]);
-  HEXL_CHECK_BOUNDS(ExtractValues(*Y).data(), 8,
-                    2 * ExtractValues(twice_modulus).data()[0],
-                    "FwdButterfly input Y exceeds 4 * modulus "
-                        << 2 * ExtractValues(twice_modulus).data()[0]);
-
   if (!InputLessThanMod) {
     *X = _mm512_hexl_small_mod_epu64(*X, twice_modulus);
   }
@@ -100,15 +91,6 @@ void FwdButterfly(__m512i* X, __m512i* Y, __m512i W, __m512i W_precon,
   __m512i twice_mod_minus_T = _mm512_sub_epi64(twice_modulus, T);
   *Y = _mm512_add_epi64(*X, twice_mod_minus_T);
   *X = _mm512_add_epi64(*X, T);
-
-  HEXL_CHECK_BOUNDS(ExtractValues(*X).data(), 8,
-                    2 * ExtractValues(twice_modulus).data()[0],
-                    "FwdButterfly output X exceeds 4 * modulus "
-                        << 2 * ExtractValues(twice_modulus).data()[0]);
-  HEXL_CHECK_BOUNDS(ExtractValues(*Y).data(), 8,
-                    2 * ExtractValues(twice_modulus).data()[0],
-                    "FwdButterfly output Y exceeds 4 * modulus "
-                        << 2 * ExtractValues(twice_modulus).data()[0]);
 }
 
 template <int BitShift>

--- a/hexl/ntt/fwd-ntt-avx512.cpp
+++ b/hexl/ntt/fwd-ntt-avx512.cpp
@@ -61,14 +61,6 @@ template void ForwardTransformToBitReverseAVX512<NTT::s_default_shift_bits>(
 template <int BitShift, bool InputLessThanMod>
 void FwdButterfly(__m512i* X, __m512i* Y, __m512i W, __m512i W_precon,
                   __m512i neg_modulus, __m512i twice_modulus) {
-  HEXL_VLOG(5, " ");
-  HEXL_VLOG(5, "FwdButterfly AVX512 inputs");
-  HEXL_VLOG(5, "X " << ExtractValues(*X));
-  HEXL_VLOG(5, "Y " << ExtractValues(*Y));
-  HEXL_VLOG(5, "W " << ExtractValues(W));
-  HEXL_VLOG(5, "modulus " << ExtractValues(twice_modulus)[0] / 2);
-  HEXL_VLOG(5, "W_precon " << ExtractValues(W_precon));
-
   HEXL_CHECK_BOUNDS(ExtractValues(*Y).data(), 8,
                     2 * ExtractValues(twice_modulus).data()[0],
                     "FwdButterfly input Y exceeds 4 * modulus "
@@ -79,11 +71,8 @@ void FwdButterfly(__m512i* X, __m512i* Y, __m512i W, __m512i W_precon,
                         << 2 * ExtractValues(twice_modulus).data()[0]);
 
   if (!InputLessThanMod) {
-    HEXL_VLOG(5, "HEXL small modding");
     *X = _mm512_hexl_small_mod_epu64(*X, twice_modulus);
   }
-
-  HEXL_VLOG(5, "X in [0,2q] " << ExtractValues(*X));
 
   __m512i T;
   if (BitShift == 32) {
@@ -108,15 +97,9 @@ void FwdButterfly(__m512i* X, __m512i* Y, __m512i W, __m512i W_precon,
     HEXL_CHECK(false, "Invalid BitShift " << BitShift);
   }
 
-  HEXL_VLOG(5, "T " << ExtractValues(T));
-
   __m512i twice_mod_minus_T = _mm512_sub_epi64(twice_modulus, T);
   *Y = _mm512_add_epi64(*X, twice_mod_minus_T);
   *X = _mm512_add_epi64(*X, T);
-
-  HEXL_VLOG(5, "FwdButterfly AVX512 outputs");
-  HEXL_VLOG(5, "X " << ExtractValues(*X));
-  HEXL_VLOG(5, "Y " << ExtractValues(*Y));
 
   HEXL_CHECK_BOUNDS(ExtractValues(*X).data(), 8,
                     2 * ExtractValues(twice_modulus).data()[0],

--- a/hexl/ntt/inv-ntt-avx512.cpp
+++ b/hexl/ntt/inv-ntt-avx512.cpp
@@ -63,23 +63,6 @@ template void InverseTransformFromBitReverseAVX512<NTT::s_default_shift_bits>(
 template <int BitShift, bool InputLessThanMod>
 inline void InvButterfly(__m512i* X, __m512i* Y, __m512i W, __m512i W_precon,
                          __m512i neg_modulus, __m512i twice_modulus) {
-  HEXL_VLOG(5, " ");
-  HEXL_VLOG(5, "InvButterfly AVX512 inputs");
-  HEXL_VLOG(5, "modulus " << ExtractValues(twice_modulus)[0] / 2);
-  HEXL_VLOG(5, "X " << ExtractValues(*X));
-  HEXL_VLOG(5, "Y " << ExtractValues(*Y));
-  HEXL_VLOG(5, "W " << ExtractValues(W));
-  HEXL_VLOG(5, "W_precon " << ExtractValues(W_precon));
-
-  HEXL_CHECK_BOUNDS(ExtractValues(*Y).data(), 8,
-                    ExtractValues(twice_modulus).data()[0],
-                    "FwdButterfly input Y exceeds 2 * modulus "
-                        << ExtractValues(twice_modulus).data()[0]);
-  HEXL_CHECK_BOUNDS(ExtractValues(*Y).data(), 8,
-                    ExtractValues(twice_modulus).data()[0],
-                    "FwdButterfly input Y exceeds 2 * modulus "
-                        << ExtractValues(twice_modulus).data()[0]);
-
   __m512i Y_minus_2q = _mm512_sub_epi64(*Y, twice_modulus);
   __m512i T = _mm512_sub_epi64(*X, Y_minus_2q);
 
@@ -113,15 +96,6 @@ inline void InvButterfly(__m512i* X, __m512i* Y, __m512i W, __m512i W_precon,
   } else {
     HEXL_CHECK(false, "Invalid BitShift " << BitShift);
   }
-
-  HEXL_CHECK_BOUNDS(ExtractValues(*Y).data(), 8,
-                    ExtractValues(twice_modulus).data()[0],
-                    "FwdButterfly output Y exceeds 2 * modulus "
-                        << ExtractValues(twice_modulus).data()[0]);
-  HEXL_CHECK_BOUNDS(ExtractValues(*Y).data(), 8,
-                    ExtractValues(twice_modulus).data()[0],
-                    "FwdButterfly output Y exceeds 2 * modulus "
-                        << ExtractValues(twice_modulus).data()[0]);
 }
 
 template <int BitShift, bool InputLessThanMod>
@@ -130,7 +104,6 @@ void InvT1(uint64_t* operand, __m512i v_neg_modulus, __m512i v_twice_mod,
   const __m512i* v_W_pt = reinterpret_cast<const __m512i*>(W);
   const __m512i* v_W_precon_pt = reinterpret_cast<const __m512i*>(W_precon);
   size_t j1 = 0;
-  HEXL_VLOG(3, "InvT1 with InputLessThanMod " << InputLessThanMod);
 
   // 8 | m guaranteed by n >= 16
   HEXL_LOOP_UNROLL_8
@@ -269,8 +242,6 @@ void InverseTransformFromBitReverseAVX512(
              "input_mod_factor must be 1 or 2; got " << input_mod_factor);
   HEXL_CHECK(output_mod_factor == 1 || output_mod_factor == 2,
              "output_mod_factor must be 1 or 2; got " << output_mod_factor);
-
-  HEXL_VLOG(3, "modulus " << modulus)
 
   uint64_t twice_mod = modulus << 1;
   __m512i v_modulus = _mm512_set1_epi64(static_cast<int64_t>(modulus));

--- a/hexl/ntt/inv-ntt-avx512.cpp
+++ b/hexl/ntt/inv-ntt-avx512.cpp
@@ -63,6 +63,23 @@ template void InverseTransformFromBitReverseAVX512<NTT::s_default_shift_bits>(
 template <int BitShift, bool InputLessThanMod>
 inline void InvButterfly(__m512i* X, __m512i* Y, __m512i W, __m512i W_precon,
                          __m512i neg_modulus, __m512i twice_modulus) {
+  HEXL_VLOG(5, " ");
+  HEXL_VLOG(5, "InvButterfly AVX512 inputs");
+  HEXL_VLOG(5, "modulus " << ExtractValues(twice_modulus)[0] / 2);
+  HEXL_VLOG(5, "X " << ExtractValues(*X));
+  HEXL_VLOG(5, "Y " << ExtractValues(*Y));
+  HEXL_VLOG(5, "W " << ExtractValues(W));
+  HEXL_VLOG(5, "W_precon " << ExtractValues(W_precon));
+
+  HEXL_CHECK_BOUNDS(ExtractValues(*Y).data(), 8,
+                    ExtractValues(twice_modulus).data()[0],
+                    "FwdButterfly input Y exceeds 2 * modulus "
+                        << ExtractValues(twice_modulus).data()[0]);
+  HEXL_CHECK_BOUNDS(ExtractValues(*Y).data(), 8,
+                    ExtractValues(twice_modulus).data()[0],
+                    "FwdButterfly input Y exceeds 2 * modulus "
+                        << ExtractValues(twice_modulus).data()[0]);
+
   __m512i Y_minus_2q = _mm512_sub_epi64(*Y, twice_modulus);
   __m512i T = _mm512_sub_epi64(*X, Y_minus_2q);
 
@@ -96,6 +113,15 @@ inline void InvButterfly(__m512i* X, __m512i* Y, __m512i W, __m512i W_precon,
   } else {
     HEXL_CHECK(false, "Invalid BitShift " << BitShift);
   }
+
+  HEXL_CHECK_BOUNDS(ExtractValues(*Y).data(), 8,
+                    ExtractValues(twice_modulus).data()[0],
+                    "FwdButterfly output Y exceeds 2 * modulus "
+                        << ExtractValues(twice_modulus).data()[0]);
+  HEXL_CHECK_BOUNDS(ExtractValues(*Y).data(), 8,
+                    ExtractValues(twice_modulus).data()[0],
+                    "FwdButterfly output Y exceeds 2 * modulus "
+                        << ExtractValues(twice_modulus).data()[0]);
 }
 
 template <int BitShift, bool InputLessThanMod>
@@ -104,6 +130,7 @@ void InvT1(uint64_t* operand, __m512i v_neg_modulus, __m512i v_twice_mod,
   const __m512i* v_W_pt = reinterpret_cast<const __m512i*>(W);
   const __m512i* v_W_precon_pt = reinterpret_cast<const __m512i*>(W_precon);
   size_t j1 = 0;
+  HEXL_VLOG(3, "InvT1 with InputLessThanMod " << InputLessThanMod);
 
   // 8 | m guaranteed by n >= 16
   HEXL_LOOP_UNROLL_8
@@ -243,6 +270,8 @@ void InverseTransformFromBitReverseAVX512(
   HEXL_CHECK(output_mod_factor == 1 || output_mod_factor == 2,
              "output_mod_factor must be 1 or 2; got " << output_mod_factor);
 
+  HEXL_VLOG(3, "modulus " << modulus)
+
   uint64_t twice_mod = modulus << 1;
   __m512i v_modulus = _mm512_set1_epi64(static_cast<int64_t>(modulus));
   __m512i v_neg_modulus = _mm512_set1_epi64(-static_cast<int64_t>(modulus));
@@ -260,7 +289,7 @@ void InverseTransformFromBitReverseAVX512(
       // t = 1
       const uint64_t* W = &inv_root_of_unity_powers[W_idx];
       const uint64_t* W_precon = &precon_inv_root_of_unity_powers[W_idx];
-      if (input_mod_factor == 1) {
+      if ((input_mod_factor == 1) && (recursion_depth == 0)) {
         InvT1<BitShift, true>(operand, v_neg_modulus, v_twice_mod, m, W,
                               W_precon);
       } else {

--- a/test/test-eltwise-add-mod-avx512.cpp
+++ b/test/test-eltwise-add-mod-avx512.cpp
@@ -52,7 +52,7 @@ TEST(EltwiseAddMod, vector_vector_avx512_big) {
     GTEST_SKIP();
   }
 
-  uint64_t modulus = GeneratePrimes(1, 60, 1024)[0];
+  uint64_t modulus = GeneratePrimes(1, 60, true, 1024)[0];
 
   std::vector<uint64_t> op1{modulus - 1, modulus - 1, modulus - 2, modulus - 2,
                             modulus - 3, modulus - 3, modulus - 4, modulus - 4};
@@ -72,7 +72,7 @@ TEST(EltwiseAddMod, vector_scalar_avx512_big) {
     GTEST_SKIP();
   }
 
-  uint64_t modulus = GeneratePrimes(1, 60, 1024)[0];
+  uint64_t modulus = GeneratePrimes(1, 60, true, 1024)[0];
 
   std::vector<uint64_t> op1{modulus - 1, modulus - 1, modulus - 2, modulus - 2,
                             modulus - 3, modulus - 3, modulus - 4, modulus - 4};

--- a/test/test-eltwise-add-mod.cpp
+++ b/test/test-eltwise-add-mod.cpp
@@ -81,7 +81,7 @@ TEST(EltwiseAddMod, vector_scalar_native_small) {
 }
 
 TEST(EltwiseAddMod, vector_vector_native_big) {
-  uint64_t modulus = GeneratePrimes(1, 60, 1024)[0];
+  uint64_t modulus = GeneratePrimes(1, 60, true, 1024)[0];
 
   std::vector<uint64_t> op1{modulus - 1, modulus - 1, modulus - 2, modulus - 2,
                             modulus - 3, modulus - 3, modulus - 4, modulus - 4};
@@ -97,7 +97,7 @@ TEST(EltwiseAddMod, vector_vector_native_big) {
 }
 
 TEST(EltwiseAddMod, vector_scalar_native_big) {
-  uint64_t modulus = GeneratePrimes(1, 60, 1024)[0];
+  uint64_t modulus = GeneratePrimes(1, 60, true, 1024)[0];
 
   std::vector<uint64_t> op1{modulus - 1, modulus - 1, modulus - 2, modulus - 2,
                             modulus - 3, modulus - 3, modulus - 4, modulus - 4};

--- a/test/test-eltwise-cmp-sub-mod-avx512.cpp
+++ b/test/test-eltwise-cmp-sub-mod-avx512.cpp
@@ -31,7 +31,7 @@ TEST(EltwiseCmpSubMod, AVX512) {
 
   for (size_t cmp = 0; cmp < 8; ++cmp) {
     for (size_t bits = 48; bits <= 51; ++bits) {
-      uint64_t modulus = GeneratePrimes(1, bits, 1024)[0];
+      uint64_t modulus = GeneratePrimes(1, bits, true, 1024)[0];
       std::uniform_int_distribution<uint64_t> distrib(0, modulus - 1);
 
       for (size_t trial = 0; trial < 200; ++trial) {

--- a/test/test-eltwise-fma-mod-avx512.cpp
+++ b/test/test-eltwise-fma-mod-avx512.cpp
@@ -229,7 +229,7 @@ TEST(EltwiseFMAMod, AVX512IFMA) {
   constexpr uint64_t input_mod_factor = 8;
 
   for (size_t bits = 48; bits <= 51; ++bits) {
-    uint64_t modulus = GeneratePrimes(1, bits, length)[0];
+    uint64_t modulus = GeneratePrimes(1, bits, true, length)[0];
     std::uniform_int_distribution<uint64_t> distrib(
         0, input_mod_factor * modulus - 1);
 

--- a/test/test-eltwise-mult-mod-avx512.cpp
+++ b/test/test-eltwise-mult-mod-avx512.cpp
@@ -39,7 +39,7 @@ TEST(EltwiseMultMod, avx512_int2) {
   if (!has_avx512dq) {
     GTEST_SKIP();
   }
-  uint64_t modulus = GeneratePrimes(1, 60, 1024)[0];
+  uint64_t modulus = GeneratePrimes(1, 60, true, 1024)[0];
 
   std::vector<uint64_t> op1{modulus - 3, 1, 1, 1, 1, 1, 1, 1};
   std::vector<uint64_t> op2{modulus - 4, 1, 1, 1, 1, 1, 1, 1};

--- a/test/test-eltwise-mult-mod.cpp
+++ b/test/test-eltwise-mult-mod.cpp
@@ -77,7 +77,7 @@ TEST(EltwiseMultModInPlace, 8_bounds) {
 #endif
 
 TEST(EltwiseMultModInPlace, 9) {
-  uint64_t modulus = GeneratePrimes(1, 51, 1024)[0];
+  uint64_t modulus = GeneratePrimes(1, 51, true, 1024)[0];
 
   std::vector<uint64_t> op1{modulus - 3, 1, 2, 3, 4, 5, 6, 7, 8};
   std::vector<uint64_t> op2{modulus - 4, 8, 7, 6, 5, 4, 3, 2, 1};
@@ -105,7 +105,7 @@ TEST(EltwiseMultMod, native_mult2) {
 }
 
 TEST(EltwiseMultMod, native2_big) {
-  uint64_t modulus = GeneratePrimes(1, 60, 1024)[0];
+  uint64_t modulus = GeneratePrimes(1, 60, true, 1024)[0];
 
   std::vector<uint64_t> op1{modulus - 3, 1, 1, 1, 1, 1, 1, 1};
   std::vector<uint64_t> op2{modulus - 4, 1, 1, 1, 1, 1, 1, 1};
@@ -119,7 +119,7 @@ TEST(EltwiseMultMod, native2_big) {
 }
 
 TEST(EltwiseMultMod, 8big) {
-  uint64_t modulus = GeneratePrimes(1, 48, 1024)[0];
+  uint64_t modulus = GeneratePrimes(1, 48, true, 1024)[0];
 
   std::vector<uint64_t> op1{modulus - 1, 1, 1, 1, 1, 1, 1, 1};
   std::vector<uint64_t> op2{modulus - 1, 1, 1, 1, 1, 1, 1, 1};
@@ -198,7 +198,7 @@ TEST(EltwiseMultMod, 8_bounds) {
 #endif
 
 TEST(EltwiseMultMod, 9) {
-  uint64_t modulus = GeneratePrimes(1, 51, 1024)[0];
+  uint64_t modulus = GeneratePrimes(1, 51, true, 1024)[0];
 
   std::vector<uint64_t> op1{modulus - 3, 1, 2, 3, 4, 5, 6, 7, 8};
   std::vector<uint64_t> op2{modulus - 4, 8, 7, 6, 5, 4, 3, 2, 1};

--- a/test/test-eltwise-reduce-mod-avx512.cpp
+++ b/test/test-eltwise-reduce-mod-avx512.cpp
@@ -100,7 +100,7 @@ TEST(EltwiseReduceMod, AVX512Big_0_1) {
   size_t length = 1024;
 
   for (size_t bits = 50; bits <= 62; ++bits) {
-    uint64_t modulus = GeneratePrimes(1, bits, length)[0];
+    uint64_t modulus = GeneratePrimes(1, bits, true, length)[0];
     std::uniform_int_distribution<uint64_t> distrib(0, modulus - 1);
 
 #ifdef HEXL_DEBUG
@@ -139,7 +139,7 @@ TEST(EltwiseReduceMod, AVX512Big_4_1) {
   size_t length = 1024;
 
   for (size_t bits = 50; bits <= 62; ++bits) {
-    uint64_t modulus = GeneratePrimes(1, bits, length)[0];
+    uint64_t modulus = GeneratePrimes(1, bits, true, length)[0];
     std::uniform_int_distribution<uint64_t> distrib(0, (4 * modulus) - 1);
 
 #ifdef HEXL_DEBUG
@@ -178,7 +178,7 @@ TEST(EltwiseReduceMod, AVX512Big_4_2) {
   size_t length = 1024;
 
   for (size_t bits = 50; bits <= 62; ++bits) {
-    uint64_t modulus = GeneratePrimes(1, bits, length)[0];
+    uint64_t modulus = GeneratePrimes(1, bits, true, length)[0];
     std::uniform_int_distribution<uint64_t> distrib(0, (4 * modulus) - 1);
 
 #ifdef HEXL_DEBUG
@@ -217,7 +217,7 @@ TEST(EltwiseReduceMod, AVX512Big_2_1) {
   size_t length = 1024;
 
   for (size_t bits = 50; bits <= 62; ++bits) {
-    uint64_t modulus = GeneratePrimes(1, bits, length)[0];
+    uint64_t modulus = GeneratePrimes(1, bits, true, length)[0];
     std::uniform_int_distribution<uint64_t> distrib(0, (2 * modulus) - 1);
 
 #ifdef HEXL_DEBUG

--- a/test/test-eltwise-sub-mod-avx512.cpp
+++ b/test/test-eltwise-sub-mod-avx512.cpp
@@ -52,7 +52,7 @@ TEST(EltwiseSubMod, vector_vector_avx512_big) {
     GTEST_SKIP();
   }
 
-  uint64_t modulus = GeneratePrimes(1, 60, 1024)[0];
+  uint64_t modulus = GeneratePrimes(1, 60, true, 1024)[0];
 
   std::vector<uint64_t> op1{0,           1,           2,           3,
                             modulus - 1, modulus - 2, modulus - 3, modulus - 4};
@@ -71,7 +71,7 @@ TEST(EltwiseSubMod, vector_scalar_avx512_big) {
     GTEST_SKIP();
   }
 
-  uint64_t modulus = GeneratePrimes(1, 60, 1024)[0];
+  uint64_t modulus = GeneratePrimes(1, 60, true, 1024)[0];
 
   std::vector<uint64_t> op1{0,           1,           2,           3,
                             modulus - 1, modulus - 2, modulus - 3, modulus - 4};

--- a/test/test-eltwise-sub-mod.cpp
+++ b/test/test-eltwise-sub-mod.cpp
@@ -81,7 +81,7 @@ TEST(EltwiseSubMod, vector_scalar_native_small) {
 }
 
 TEST(EltwiseSubMod, vector_vector_native_big) {
-  uint64_t modulus = GeneratePrimes(1, 60, 1024)[0];
+  uint64_t modulus = GeneratePrimes(1, 60, true, 1024)[0];
 
   std::vector<uint64_t> op1{0,           1,           2,           3,
                             modulus - 1, modulus - 2, modulus - 3, modulus - 4};
@@ -96,7 +96,7 @@ TEST(EltwiseSubMod, vector_vector_native_big) {
 }
 
 TEST(EltwiseSubMod, vector_scalar_native_big) {
-  uint64_t modulus = GeneratePrimes(1, 60, 1024)[0];
+  uint64_t modulus = GeneratePrimes(1, 60, true, 1024)[0];
 
   std::vector<uint64_t> op1{0,           1,           2,           3,
                             modulus - 1, modulus - 2, modulus - 3, modulus - 4};

--- a/test/test-ntt.cpp
+++ b/test/test-ntt.cpp
@@ -426,7 +426,7 @@ TEST_P(DegreeModulusTest, InverseRadix4Random) {
   uint64_t modulus = GeneratePrimes(1, modulus_bits, true, N)[0];
 
   std::random_device rd;
-  std::mt19937 gen(42);  // rd());
+  std::mt19937 gen(rd());
   std::uniform_int_distribution<uint64_t> distrib(1, modulus - 1);
 
   std::vector<uint64_t> input(N);

--- a/test/test-ntt.cpp
+++ b/test/test-ntt.cpp
@@ -368,7 +368,7 @@ class DegreeModulusTest
 TEST_P(DegreeModulusTest, ForwardZeros) {
   uint64_t N = std::get<0>(GetParam());
   uint64_t modulus_bits = std::get<1>(GetParam());
-  uint64_t modulus = GeneratePrimes(1, modulus_bits, N)[0];
+  uint64_t modulus = GeneratePrimes(1, modulus_bits, true, N)[0];
 
   std::vector<uint64_t> input(N, 0);
   std::vector<uint64_t> exp_output(N, 0);
@@ -382,7 +382,7 @@ TEST_P(DegreeModulusTest, ForwardZeros) {
 TEST_P(DegreeModulusTest, InverseZeros) {
   uint64_t N = std::get<0>(GetParam());
   uint64_t modulus_bits = std::get<1>(GetParam());
-  uint64_t modulus = GeneratePrimes(1, modulus_bits, N)[0];
+  uint64_t modulus = GeneratePrimes(1, modulus_bits, true, N)[0];
 
   std::vector<uint64_t> input(N, 0);
   std::vector<uint64_t> exp_output(N, 0);
@@ -396,7 +396,7 @@ TEST_P(DegreeModulusTest, InverseZeros) {
 TEST_P(DegreeModulusTest, ForwardRadix4Random) {
   uint64_t N = std::get<0>(GetParam());
   uint64_t modulus_bits = std::get<1>(GetParam());
-  uint64_t modulus = GeneratePrimes(1, modulus_bits, N)[0];
+  uint64_t modulus = GeneratePrimes(1, modulus_bits, true, N)[0];
 
   std::random_device rd;
   std::mt19937 gen(rd());
@@ -423,7 +423,7 @@ TEST_P(DegreeModulusTest, ForwardRadix4Random) {
 TEST_P(DegreeModulusTest, InverseRadix4Random) {
   uint64_t N = std::get<0>(GetParam());
   uint64_t modulus_bits = std::get<1>(GetParam());
-  uint64_t modulus = GeneratePrimes(1, modulus_bits, N)[0];
+  uint64_t modulus = GeneratePrimes(1, modulus_bits, true, N)[0];
 
   std::random_device rd;
   std::mt19937 gen(42);  // rd());

--- a/test/test-number-theory.cpp
+++ b/test/test-number-theory.cpp
@@ -336,7 +336,17 @@ TEST(NumberTheory, IsPrime) {
 
 TEST(NumberTheory, GeneratePrimes) {
   for (int bit_size = 40; bit_size < 62; ++bit_size) {
-    std::vector<uint64_t> primes = GeneratePrimes(10, bit_size, 4096);
+    std::vector<uint64_t> primes = GeneratePrimes(10, bit_size, true, 4096);
+    ASSERT_EQ(primes.size(), 10);
+    for (const auto& prime : primes) {
+      ASSERT_EQ(prime % 8192, 1);
+      ASSERT_TRUE(IsPrime(prime));
+      ASSERT_TRUE(prime <= (1ULL << (bit_size + 1)));
+      ASSERT_TRUE(prime >= (1ULL << bit_size));
+    }
+  }
+  for (int bit_size = 40; bit_size < 62; ++bit_size) {
+    std::vector<uint64_t> primes = GeneratePrimes(10, bit_size, false, 4096);
     ASSERT_EQ(primes.size(), 10);
     for (const auto& prime : primes) {
       ASSERT_EQ(prime % 8192, 1);


### PR DESCRIPTION
Fixes bug in AVX512 NTT that appeared in the IFMA implementation with primes close to 2**50.  Added `bool prefer_small_primes` parameter to `GeneratePrimes()` which is used to trigger the failing condition.