### PR TITLE
Fix Barrett reduce native benchmark

### DIFF
--- a/benchmark/bench-eltwise-cmp-add.cpp
+++ b/benchmark/bench-eltwise-cmp-add.cpp
@@ -23,9 +23,9 @@ static void BM_EltwiseCmpAddNative(benchmark::State& state) {  //  NOLINT
 
   uint64_t modulus = 100;
 
-  uint64_t bound = GenerateInsecureUniformRandomValue(modulus);
-  uint64_t diff = GenerateInsecureUniformRandomValue(modulus - 1) + 1;
-  auto input1 = GenerateInsecureUniformRandomValues(input_size, modulus);
+  uint64_t bound = GenerateInsecureUniformRandomValue(0, modulus);
+  uint64_t diff = GenerateInsecureUniformRandomValue(1, modulus - 1);
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
 
   for (auto _ : state) {
     EltwiseCmpAddNative(input1.data(), input1.data(), input_size, CMPINT::NLT,
@@ -48,8 +48,8 @@ static void BM_EltwiseCmpAddAVX512(benchmark::State& state) {  //  NOLINT
 
   uint64_t bound = 50;
   // must be non-zero
-  uint64_t diff = GenerateInsecureUniformRandomValue(bound - 1) + 1;
-  auto input1 = GenerateInsecureUniformRandomValues(input_size, bound);
+  uint64_t diff = GenerateInsecureUniformRandomValue(1, bound - 1);
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, bound);
 
   for (auto _ : state) {
     EltwiseCmpAddAVX512(input1.data(), input1.data(), input_size, CMPINT::NLT,

--- a/benchmark/bench-eltwise-cmp-sub-mod.cpp
+++ b/benchmark/bench-eltwise-cmp-sub-mod.cpp
@@ -46,7 +46,7 @@ static void BM_EltwiseCmpSubModAVX512(benchmark::State& state) {  //  NOLINT
   size_t input_size = state.range(0);
   uint64_t modulus = 100;
   uint64_t bound = GenerateInsecureUniformRandomValue(0, modulus);
-  uint64_t diff = GenerateInsecureUniformRandomValue(0, modulus);
+  uint64_t diff = GenerateInsecureUniformRandomValue(1, modulus);
   auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
 
   for (auto _ : state) {

--- a/benchmark/bench-eltwise-cmp-sub-mod.cpp
+++ b/benchmark/bench-eltwise-cmp-sub-mod.cpp
@@ -22,9 +22,9 @@ static void BM_EltwiseCmpSubModNative(benchmark::State& state) {  //  NOLINT
   size_t input_size = state.range(0);
 
   uint64_t modulus = 100;
-  uint64_t bound = GenerateInsecureUniformRandomValue(modulus - 1) + 1;
-  uint64_t diff = GenerateInsecureUniformRandomValue(modulus - 1) + 1;
-  auto input1 = GenerateInsecureUniformRandomValues(input_size, modulus);
+  uint64_t bound = GenerateInsecureUniformRandomValue(1, modulus);
+  uint64_t diff = GenerateInsecureUniformRandomValue(1, modulus);
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
 
   for (auto _ : state) {
     EltwiseCmpSubModNative(input1.data(), input1.data(), input_size, modulus,
@@ -45,9 +45,9 @@ BENCHMARK(BM_EltwiseCmpSubModNative)
 static void BM_EltwiseCmpSubModAVX512(benchmark::State& state) {  //  NOLINT
   size_t input_size = state.range(0);
   uint64_t modulus = 100;
-  uint64_t bound = GenerateInsecureUniformRandomValue(modulus);
-  uint64_t diff = GenerateInsecureUniformRandomValue(modulus);
-  auto input1 = GenerateInsecureUniformRandomValues(input_size, modulus);
+  uint64_t bound = GenerateInsecureUniformRandomValue(0, modulus);
+  uint64_t diff = GenerateInsecureUniformRandomValue(0, modulus);
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
 
   for (auto _ : state) {
     EltwiseCmpSubModAVX512(input1.data(), input1.data(), input_size, modulus,

--- a/benchmark/bench-eltwise-reduce-mod.cpp
+++ b/benchmark/bench-eltwise-reduce-mod.cpp
@@ -11,6 +11,7 @@
 #include "hexl/logging/logging.hpp"
 #include "hexl/number-theory/number-theory.hpp"
 #include "hexl/util/aligned-allocator.hpp"
+#include "util/util-internal.hpp"
 
 namespace intel {
 namespace hexl {
@@ -20,7 +21,8 @@ static void BM_EltwiseReduceModInPlace(benchmark::State& state) {  //  NOLINT
   size_t input_size = state.range(0);
   uint64_t modulus = 0xffffffffffc0001ULL;
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
+  AlignedVector64<uint64_t> input1 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   const uint64_t input_mod_factor = 0;
   const uint64_t output_mod_factor = 1;
   for (auto _ : state) {
@@ -42,7 +44,8 @@ static void BM_EltwiseReduceModCopy(benchmark::State& state) {  //  NOLINT
   size_t input_size = state.range(0);
   uint64_t modulus = 0xffffffffffc0001ULL;
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
+  AlignedVector64<uint64_t> input1 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   const uint64_t input_mod_factor = 0;
   const uint64_t output_mod_factor = 1;
   AlignedVector64<uint64_t> output(input_size, 0);
@@ -66,7 +69,8 @@ static void BM_EltwiseReduceModNative(benchmark::State& state) {  //  NOLINT
   size_t input_size = state.range(0);
   uint64_t modulus = 0xffffffffffc0001ULL;
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
+  AlignedVector64<uint64_t> input1 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus * 2);
   const uint64_t input_mod_factor = 0;
   const uint64_t output_mod_factor = 1;
   AlignedVector64<uint64_t> output(input_size, 0);
@@ -91,7 +95,8 @@ static void BM_EltwiseReduceModAVX512(benchmark::State& state) {  //  NOLINT
   size_t input_size = state.range(0);
   size_t modulus = 1152921504606877697;
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
+  AlignedVector64<uint64_t> input1 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   const uint64_t input_mod_factor = 0;
   const uint64_t output_mod_factor = 1;
   AlignedVector64<uint64_t> output(input_size, 0);

--- a/benchmark/bench-eltwise-reduce-mod.cpp
+++ b/benchmark/bench-eltwise-reduce-mod.cpp
@@ -69,8 +69,8 @@ static void BM_EltwiseReduceModNative(benchmark::State& state) {  //  NOLINT
   size_t input_size = state.range(0);
   uint64_t modulus = 0xffffffffffc0001ULL;
 
-  AlignedVector64<uint64_t> input1 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus * 2);
+  AlignedVector64<uint64_t> input1 = GenerateInsecureUniformRandomValues(
+      input_size, modulus, modulus * modulus);
   const uint64_t input_mod_factor = 0;
   const uint64_t output_mod_factor = 1;
   AlignedVector64<uint64_t> output(input_size, 0);

--- a/benchmark/bench-eltwise-reduce-mod.cpp
+++ b/benchmark/bench-eltwise-reduce-mod.cpp
@@ -22,7 +22,7 @@ static void BM_EltwiseReduceModInPlace(benchmark::State& state) {  //  NOLINT
   uint64_t modulus = 0xffffffffffc0001ULL;
 
   AlignedVector64<uint64_t> input1 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+      GenerateInsecureUniformRandomValues(input_size, 0, 100 * modulus);
   const uint64_t input_mod_factor = 0;
   const uint64_t output_mod_factor = 1;
   for (auto _ : state) {
@@ -45,7 +45,7 @@ static void BM_EltwiseReduceModCopy(benchmark::State& state) {  //  NOLINT
   uint64_t modulus = 0xffffffffffc0001ULL;
 
   AlignedVector64<uint64_t> input1 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+      GenerateInsecureUniformRandomValues(input_size, 0, 100 * modulus);
   const uint64_t input_mod_factor = 0;
   const uint64_t output_mod_factor = 1;
   AlignedVector64<uint64_t> output(input_size, 0);
@@ -69,8 +69,8 @@ static void BM_EltwiseReduceModNative(benchmark::State& state) {  //  NOLINT
   size_t input_size = state.range(0);
   uint64_t modulus = 0xffffffffffc0001ULL;
 
-  AlignedVector64<uint64_t> input1 = GenerateInsecureUniformRandomValues(
-      input_size, modulus, modulus * modulus);
+  AlignedVector64<uint64_t> input1 =
+      GenerateInsecureUniformRandomValues(input_size, 0, 100 * modulus);
   const uint64_t input_mod_factor = 0;
   const uint64_t output_mod_factor = 1;
   AlignedVector64<uint64_t> output(input_size, 0);
@@ -96,7 +96,7 @@ static void BM_EltwiseReduceModAVX512(benchmark::State& state) {  //  NOLINT
   size_t modulus = 1152921504606877697;
 
   AlignedVector64<uint64_t> input1 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+      GenerateInsecureUniformRandomValues(input_size, 0, 100 * modulus);
   const uint64_t input_mod_factor = 0;
   const uint64_t output_mod_factor = 1;
   AlignedVector64<uint64_t> output(input_size, 0);

--- a/hexl/eltwise/eltwise-reduce-mod.cpp
+++ b/hexl/eltwise/eltwise-reduce-mod.cpp
@@ -35,11 +35,7 @@ void EltwiseReduceModNative(uint64_t* result, const uint64_t* operand,
   switch (input_mod_factor) {
     case 0:
       for (size_t i = 0; i < n; ++i) {
-        if (operand[i] >= modulus) {
-          result[i] = BarrettReduce64(operand[i], modulus, barrett_factor);
-        } else {
-          result[i] = operand[i];
-        }
+        result[i] = BarrettReduce64(operand[i], modulus, barrett_factor);
       }
       HEXL_CHECK_BOUNDS(result, n, modulus, "result exceeds bound " << modulus);
       break;

--- a/hexl/include/hexl/number-theory/number-theory.hpp
+++ b/hexl/include/hexl/number-theory/number-theory.hpp
@@ -192,7 +192,13 @@ std::vector<uint64_t> GeneratePrimes(size_t num_primes, size_t bit_size,
 /// @param[in] input
 /// @param[in] modulus
 /// @param[in] q_barr floor(2^64 / modulus)
-uint64_t BarrettReduce64(uint64_t input, uint64_t modulus, uint64_t q_barr);
+inline uint64_t BarrettReduce64(uint64_t input, uint64_t modulus,
+                                uint64_t q_barr) {
+  HEXL_CHECK(modulus != 0, "modulus == 0");
+  uint64_t q = MultiplyUInt64Hi<64>(input, q_barr);
+  uint64_t q_times_input = input - q * modulus;
+  return q_times_input >= modulus ? q_times_input - modulus : q_times_input;
+}
 
 /// @brief Returns x mod modulus, assuming x < InputModFactor * modulus
 /// @param[in] x

--- a/hexl/number-theory/number-theory.cpp
+++ b/hexl/number-theory/number-theory.cpp
@@ -41,13 +41,6 @@ uint64_t InverseMod(uint64_t input, uint64_t modulus) {
   return uint64_t(x);
 }
 
-uint64_t BarrettReduce64(uint64_t input, uint64_t modulus, uint64_t q_barr) {
-  HEXL_CHECK(modulus != 0, "modulus == 0");
-  uint64_t q = MultiplyUInt64Hi<64>(input, q_barr);
-  uint64_t q_times_input = input - q * modulus;
-  return q_times_input >= modulus ? q_times_input - modulus : q_times_input;
-}
-
 uint64_t MultiplyMod(uint64_t x, uint64_t y, uint64_t modulus) {
   HEXL_CHECK(modulus != 0, "modulus == 0");
   HEXL_CHECK(x < modulus, "x " << x << " >= modulus " << modulus);

--- a/hexl/number-theory/number-theory.cpp
+++ b/hexl/number-theory/number-theory.cpp
@@ -111,7 +111,7 @@ uint64_t GeneratePrimitiveRoot(uint64_t degree, uint64_t modulus) {
   uint64_t size_quotient_group = size_entire_group / degree;
 
   for (int trial = 0; trial < 200; ++trial) {
-    uint64_t root = GenerateInsecureUniformRandomValue(modulus);
+    uint64_t root = GenerateInsecureUniformRandomValue(0, modulus);
     root = PowMod(root, size_quotient_group, modulus);
 
     if (IsPrimitiveRoot(root, degree, modulus)) {

--- a/hexl/util/util-internal.hpp
+++ b/hexl/util/util-internal.hpp
@@ -41,28 +41,30 @@ inline bool Compare(CMPINT cmp, uint64_t lhs, uint64_t rhs) {
   }
 }
 
-/// Generates a vector of size random values drawn uniformly from [0,
-/// modulus)
+/// Generates a vector of size random values drawn uniformly from [min_value,
+/// max_value)
 /// NOTE: this function is not a cryptographically secure random number
 /// generator and should be used for testing/benchmarking only
-inline uint64_t GenerateInsecureUniformRandomValue(uint64_t modulus) {
-  HEXL_CHECK(modulus != 0, "Modulus cannot be zero");
+inline uint64_t GenerateInsecureUniformRandomValue(uint64_t min_value,
+                                                   uint64_t max_value) {
+  HEXL_CHECK(min_value < max_value, "min_value must be > max_value");
 
   static std::random_device rd;
   static std::mt19937 mersenne_engine(rd());
-  std::uniform_int_distribution<uint64_t> distrib(0, modulus - 1);
+  std::uniform_int_distribution<uint64_t> distrib(min_value, max_value - 1);
 
   return distrib(mersenne_engine);
 }
 
-/// Generates a vector of size random values drawn uniformly from [0, modulus)
-/// NOTE: this function is not a cryptographically secure random number
-/// generator and should be used for testing/benchmarking only
+/// Generates a vector of size random values drawn uniformly from [min_value,
+/// max_value)
+/// NOTE: this function is not a cryptographically secure random
+/// number generator and should be used for testing/benchmarking only
 inline AlignedVector64<uint64_t> GenerateInsecureUniformRandomValues(
-    uint64_t size, uint64_t modulus) {
+    uint64_t size, uint64_t min_value, uint64_t max_value) {
   AlignedVector64<uint64_t> values(size);
-  auto generator = [&modulus]() {
-    return GenerateInsecureUniformRandomValue(modulus);
+  auto generator = [&]() {
+    return GenerateInsecureUniformRandomValue(min_value, max_value);
   };
   std::generate(values.begin(), values.end(), generator);
   return values;

--- a/test/test-avx512-util.cpp
+++ b/test/test-avx512-util.cpp
@@ -323,7 +323,7 @@ TEST(AVX512, _mm512_hexl_barrett_reduce64) {
         _mm512_set1_epi64(MultiplyFactor(1, 64, modulus).BarrettFactor());
 
     for (size_t trial = 0; trial < 200; ++trial) {
-      auto arg1 = GenerateInsecureUniformRandomValues(8, modulus * modulus);
+      auto arg1 = GenerateInsecureUniformRandomValues(8, 0, modulus * modulus);
       auto exp = arg1;
       for (auto& elem : exp) {
         elem %= modulus;

--- a/test/test-eltwise-add-mod-avx512.cpp
+++ b/test/test-eltwise-add-mod-avx512.cpp
@@ -105,8 +105,8 @@ TEST(EltwiseAddMod, vector_vector_avx512_native_match) {
 #endif
 
     for (size_t trial = 0; trial < num_trials; ++trial) {
-      auto op1 = GenerateInsecureUniformRandomValues(length, modulus);
-      auto op2 = GenerateInsecureUniformRandomValues(length, modulus);
+      auto op1 = GenerateInsecureUniformRandomValues(length, 0, modulus);
+      auto op2 = GenerateInsecureUniformRandomValues(length, 0, modulus);
       op1[0] = modulus - 1;
       op2[0] = modulus - 1;
 
@@ -140,8 +140,8 @@ TEST(EltwiseAddMod, vector_scalar_avx512_native_match) {
 #endif
 
     for (size_t trial = 0; trial < num_trials; ++trial) {
-      auto op1 = GenerateInsecureUniformRandomValues(length, modulus);
-      uint64_t op2 = GenerateInsecureUniformRandomValue(modulus);
+      auto op1 = GenerateInsecureUniformRandomValues(length, 0, modulus);
+      uint64_t op2 = GenerateInsecureUniformRandomValue(0, modulus);
 
       auto op1a = op1;
 

--- a/test/test-eltwise-cmp-add-avx512.cpp
+++ b/test/test-eltwise-cmp-add-avx512.cpp
@@ -29,9 +29,9 @@ TEST(EltwiseCmpAdd, AVX512) {
 
   for (size_t cmp = 0; cmp < 8; ++cmp) {
     for (size_t trial = 0; trial < 200; ++trial) {
-      auto op1 = GenerateInsecureUniformRandomValues(length, modulus);
-      uint64_t bound = GenerateInsecureUniformRandomValue(modulus);
-      uint64_t diff = GenerateInsecureUniformRandomValue(modulus) + 1;
+      auto op1 = GenerateInsecureUniformRandomValues(length, 0, modulus);
+      uint64_t bound = GenerateInsecureUniformRandomValue(0, modulus);
+      uint64_t diff = GenerateInsecureUniformRandomValue(1, modulus);
 
       auto op1a = op1;
       auto op1b = op1;

--- a/test/test-eltwise-cmp-sub-mod-avx512.cpp
+++ b/test/test-eltwise-cmp-sub-mod-avx512.cpp
@@ -31,12 +31,12 @@ TEST(EltwiseCmpSubMod, AVX512) {
       uint64_t modulus = GeneratePrimes(1, bits, true, 1024)[0];
 
       for (size_t trial = 0; trial < 200; ++trial) {
-        auto op1 = GenerateInsecureUniformRandomValues(length, modulus);
-        auto op3 = GenerateInsecureUniformRandomValues(length, modulus);
+        auto op1 = GenerateInsecureUniformRandomValues(length, 0, modulus);
+        auto op3 = GenerateInsecureUniformRandomValues(length, 0, modulus);
 
-        uint64_t bound = GenerateInsecureUniformRandomValue(modulus);
+        uint64_t bound = GenerateInsecureUniformRandomValue(0, modulus);
         // Ensure diff != 0
-        uint64_t diff = GenerateInsecureUniformRandomValue(modulus - 1) + 1;
+        uint64_t diff = GenerateInsecureUniformRandomValue(1, modulus - 1);
 
         auto op1a = op1;
         auto op1b = op1;

--- a/test/test-eltwise-fma-mod-avx512.cpp
+++ b/test/test-eltwise-fma-mod-avx512.cpp
@@ -160,11 +160,11 @@ TEST(EltwiseFMAMod, AVX512DQ) {
 
       for (size_t trial = 0; trial < num_trials; ++trial) {
         auto arg1 = GenerateInsecureUniformRandomValues(
-            length, input_mod_factor * modulus);
+            length, 0, input_mod_factor * modulus);
         uint64_t arg2 =
-            GenerateInsecureUniformRandomValue(input_mod_factor * modulus);
+            GenerateInsecureUniformRandomValue(0, input_mod_factor * modulus);
         auto arg3 = GenerateInsecureUniformRandomValues(
-            length, input_mod_factor * modulus);
+            length, 0, input_mod_factor * modulus);
 
         std::vector<uint64_t> out_default(length, 0);
         std::vector<uint64_t> out_native(length, 0);
@@ -225,10 +225,10 @@ TEST(EltwiseFMAMod, AVX512IFMA) {
     uint64_t modulus = GeneratePrimes(1, bits, true, length)[0];
     for (size_t trial = 0; trial < 1000; ++trial) {
       auto arg1 = GenerateInsecureUniformRandomValues(
-          length, input_mod_factor * modulus);
-      uint64_t arg2 = GenerateInsecureUniformRandomValue(modulus);
+          length, 0, input_mod_factor * modulus);
+      uint64_t arg2 = GenerateInsecureUniformRandomValue(0, modulus);
       auto arg3 = GenerateInsecureUniformRandomValues(
-          length, input_mod_factor * modulus);
+          length, 0, input_mod_factor * modulus);
 
       auto arg1a = arg1;
       auto arg1b = arg1;

--- a/test/test-eltwise-mult-mod-avx512.cpp
+++ b/test/test-eltwise-mult-mod-avx512.cpp
@@ -103,10 +103,10 @@ TEST(EltwiseMultMod, avx512dqint_small) {
   uint64_t modulus = (1ULL << 53) + 7;
 
   for (size_t length = 1024; length <= 32768; length *= 2) {
-    auto op1 =
-        GenerateInsecureUniformRandomValues(length, input_mod_factor * modulus);
-    auto op2 =
-        GenerateInsecureUniformRandomValues(length, input_mod_factor * modulus);
+    auto op1 = GenerateInsecureUniformRandomValues(length, 0,
+                                                   input_mod_factor * modulus);
+    auto op2 = GenerateInsecureUniformRandomValues(length, 0,
+                                                   input_mod_factor * modulus);
 
     std::vector<uint64_t> out_avx(length, 0);
     std::vector<uint64_t> out_native(length, 0);
@@ -150,9 +150,9 @@ TEST(EltwiseMultMod, avx512dqint_big) {
 #endif
         for (size_t trial = 0; trial < num_trials; ++trial) {
           auto op1 = GenerateInsecureUniformRandomValues(
-              length, input_mod_factor * modulus);
+              length, 0, input_mod_factor * modulus);
           auto op2 = GenerateInsecureUniformRandomValues(
-              length, input_mod_factor * modulus);
+              length, 0, input_mod_factor * modulus);
 
           op1[0] = input_mod_factor * modulus - 1;
           op2[0] = input_mod_factor * modulus - 1;
@@ -239,9 +239,9 @@ TEST(EltwiseMultMod, avx512ifma_big) {
 #endif
         for (size_t trial = 0; trial < num_trials; ++trial) {
           auto op1 = GenerateInsecureUniformRandomValues(
-              length, input_mod_factor * modulus);
+              length, 0, input_mod_factor * modulus);
           auto op2 = GenerateInsecureUniformRandomValues(
-              length, input_mod_factor * modulus);
+              length, 0, input_mod_factor * modulus);
 
           op1[0] = input_mod_factor * modulus - 1;
           op2[0] = input_mod_factor * modulus - 1;

--- a/test/test-eltwise-reduce-mod-avx512.cpp
+++ b/test/test-eltwise-reduce-mod-avx512.cpp
@@ -107,7 +107,7 @@ TEST(EltwiseReduceMod, AVX512Big_0_1) {
     size_t num_trials = 100;
 #endif
     for (size_t trial = 0; trial < num_trials; ++trial) {
-      auto op1 = GenerateInsecureUniformRandomValues(length, modulus);
+      auto op1 = GenerateInsecureUniformRandomValues(length, 0, modulus);
       auto op2 = op1;
 
       std::vector<uint64_t> result1(length, 0);
@@ -143,7 +143,7 @@ TEST(EltwiseReduceMod, AVX512Big_4_1) {
     size_t num_trials = 100;
 #endif
     for (size_t trial = 0; trial < num_trials; ++trial) {
-      auto op1 = GenerateInsecureUniformRandomValues(length, 4 * modulus);
+      auto op1 = GenerateInsecureUniformRandomValues(length, 0, 4 * modulus);
       auto op2 = op1;
       std::vector<uint64_t> result1(length, 0);
       std::vector<uint64_t> result2(length, 0);
@@ -175,7 +175,7 @@ TEST(EltwiseReduceMod, AVX512Big_4_2) {
     size_t num_trials = 100;
 #endif
     for (size_t trial = 0; trial < num_trials; ++trial) {
-      auto op1 = GenerateInsecureUniformRandomValues(length, 4 * modulus);
+      auto op1 = GenerateInsecureUniformRandomValues(length, 0, 4 * modulus);
       auto op2 = op1;
       std::vector<uint64_t> result1(length, 0);
       std::vector<uint64_t> result2(length, 0);
@@ -207,7 +207,7 @@ TEST(EltwiseReduceMod, AVX512Big_2_1) {
     size_t num_trials = 100;
 #endif
     for (size_t trial = 0; trial < num_trials; ++trial) {
-      auto op1 = GenerateInsecureUniformRandomValues(length, 2 * modulus);
+      auto op1 = GenerateInsecureUniformRandomValues(length, 0, 2 * modulus);
       auto op2 = op1;
       std::vector<uint64_t> result1(length, 0);
       std::vector<uint64_t> result2(length, 0);

--- a/test/test-eltwise-sub-mod-avx512.cpp
+++ b/test/test-eltwise-sub-mod-avx512.cpp
@@ -103,8 +103,8 @@ TEST(EltwiseSubMod, vector_vector_avx512_native_match) {
 #endif
 
     for (size_t trial = 0; trial < num_trials; ++trial) {
-      auto op1 = GenerateInsecureUniformRandomValues(length, modulus);
-      auto op2 = GenerateInsecureUniformRandomValues(length, modulus);
+      auto op1 = GenerateInsecureUniformRandomValues(length, 0, modulus);
+      auto op2 = GenerateInsecureUniformRandomValues(length, 0, modulus);
 
       op1[0] = modulus - 1;
       op2[0] = modulus - 1;
@@ -140,8 +140,8 @@ TEST(EltwiseSubMod, vector_scalar_avx512_native_match) {
 #endif
 
     for (size_t trial = 0; trial < num_trials; ++trial) {
-      auto op1 = GenerateInsecureUniformRandomValues(length, modulus);
-      uint64_t op2 = GenerateInsecureUniformRandomValues(1, modulus)[0];
+      auto op1 = GenerateInsecureUniformRandomValues(length, 0, modulus);
+      uint64_t op2 = GenerateInsecureUniformRandomValues(1, 0, modulus)[0];
       auto op1a = op1;
 
       EltwiseSubModNative(op1.data(), op1.data(), op2, op1.size(), modulus);

--- a/test/test-ntt-avx512.cpp
+++ b/test/test-ntt-avx512.cpp
@@ -197,7 +197,7 @@ TEST_P(DegreeModulusBoolTest, FwdNTTAVX512IFMA) {
 
   for (size_t trial = 0; trial < num_trials; ++trial) {
     AlignedVector64<uint64_t> input64 =
-        GenerateInsecureUniformRandomValues(N, modulus);
+        GenerateInsecureUniformRandomValues(N, 0, modulus);
     AlignedVector64<uint64_t> input_ifma = input64;
     AlignedVector64<uint64_t> input_ifma_lazy = input64;
     AlignedVector64<uint64_t> exp_output(N, 0);
@@ -243,7 +243,7 @@ TEST_P(DegreeModulusBoolTest, InvNTTAVX512IFMA) {
 
   for (size_t trial = 0; trial < num_trials; ++trial) {
     AlignedVector64<uint64_t> input64 =
-        GenerateInsecureUniformRandomValues(N, modulus);
+        GenerateInsecureUniformRandomValues(N, 0, modulus);
     AlignedVector64<uint64_t> input_ifma = input64;
     AlignedVector64<uint64_t> input_ifma_lazy = input64;
 
@@ -303,7 +303,7 @@ TEST(NTT, FwdNTT_AVX512_32) {
 
     for (size_t trial = 0; trial < num_trials; ++trial) {
       AlignedVector64<uint64_t> input =
-          GenerateInsecureUniformRandomValues(N, modulus);
+          GenerateInsecureUniformRandomValues(N, 0, modulus);
       AlignedVector64<uint64_t> input_avx = input;
       AlignedVector64<uint64_t> input_avx_lazy = input;
 
@@ -350,7 +350,7 @@ TEST(NTT, FwdNTT_AVX512_64) {
 
     for (size_t trial = 0; trial < num_trials; ++trial) {
       AlignedVector64<uint64_t> input =
-          GenerateInsecureUniformRandomValues(N, modulus);
+          GenerateInsecureUniformRandomValues(N, 0, modulus);
       AlignedVector64<uint64_t> input_avx = input;
       AlignedVector64<uint64_t> input_avx_lazy = input;
 
@@ -397,7 +397,7 @@ TEST(NTT, InvNTT_AVX512_32) {
 
     for (size_t trial = 0; trial < num_trials; ++trial) {
       AlignedVector64<uint64_t> input =
-          GenerateInsecureUniformRandomValues(N, modulus);
+          GenerateInsecureUniformRandomValues(N, 0, modulus);
 
       AlignedVector64<uint64_t> input_avx = input;
       AlignedVector64<uint64_t> input_avx_lazy = input;
@@ -445,7 +445,7 @@ TEST(NTT, InvNTT_AVX512_64) {
 
     for (size_t trial = 0; trial < num_trials; ++trial) {
       AlignedVector64<uint64_t> input =
-          GenerateInsecureUniformRandomValues(N, modulus);
+          GenerateInsecureUniformRandomValues(N, 0, modulus);
       AlignedVector64<uint64_t> input_avx = input;
       AlignedVector64<uint64_t> input_avx_lazy = input;
 

--- a/test/test-ntt.cpp
+++ b/test/test-ntt.cpp
@@ -396,7 +396,7 @@ TEST_P(DegreeModulusTest, ForwardRadix4Random) {
   uint64_t modulus_bits = std::get<1>(GetParam());
   uint64_t modulus = GeneratePrimes(1, modulus_bits, true, N)[0];
 
-  auto input = GenerateInsecureUniformRandomValues(N, modulus);
+  auto input = GenerateInsecureUniformRandomValues(N, 0, modulus);
 
   NTT ntt(N, modulus);
 
@@ -416,7 +416,7 @@ TEST_P(DegreeModulusTest, InverseRadix4Random) {
   uint64_t modulus_bits = std::get<1>(GetParam());
   uint64_t modulus = GeneratePrimes(1, modulus_bits, true, N)[0];
 
-  auto input = GenerateInsecureUniformRandomValues(N, modulus);
+  auto input = GenerateInsecureUniformRandomValues(N, 0, modulus);
   auto input_radix4 = input;
 
   NTT ntt(N, modulus);

--- a/test/test-util-internal.cpp
+++ b/test/test-util-internal.cpp
@@ -17,7 +17,7 @@ TEST(GenerateInsecureUniformRandomValue, 10) {
 
   bool reached_max = false;
   for (size_t i = 0; i < 1000; ++i) {
-    uint64_t x = GenerateInsecureUniformRandomValue(modulus);
+    uint64_t x = GenerateInsecureUniformRandomValue(0, modulus);
     EXPECT_LT(x, modulus);
     if (x == modulus - 1) {
       reached_max = true;
@@ -31,7 +31,7 @@ TEST(GenerateInsecureUniformRandomValues, 100) {
   uint64_t length = 1024;
 
   AlignedVector64<uint64_t> values =
-      GenerateInsecureUniformRandomValues(length, modulus);
+      GenerateInsecureUniformRandomValues(length, 0, modulus);
   EXPECT_EQ(values.size(), length);
   EXPECT_TRUE(std::all_of(values.begin(), values.end(),
                           [&](uint64_t x) { return x < modulus; }));

--- a/test/test-util-internal.cpp
+++ b/test/test-util-internal.cpp
@@ -13,30 +13,41 @@ namespace intel {
 namespace hexl {
 
 TEST(GenerateInsecureUniformRandomValue, 10) {
-  uint64_t modulus = 10;
+  uint64_t max_value = 10;
+  uint64_t min_value = 5;
 
   bool reached_max = false;
+  bool reached_min = false;
   for (size_t i = 0; i < 1000; ++i) {
-    uint64_t x = GenerateInsecureUniformRandomValue(0, modulus);
-    EXPECT_LT(x, modulus);
-    if (x == modulus - 1) {
+    uint64_t x = GenerateInsecureUniformRandomValue(min_value, max_value);
+    EXPECT_LT(x, max_value);
+    EXPECT_GE(x, min_value);
+    if (x == min_value) {
+      reached_min = true;
+    }
+    if (x == max_value - 1) {
       reached_max = true;
     }
   }
+  EXPECT_TRUE(reached_min);
   EXPECT_TRUE(reached_max);
 }
 
 TEST(GenerateInsecureUniformRandomValues, 100) {
-  uint64_t modulus = 100;
+  uint64_t max_value = 100;
+  uint64_t min_value = 10;
   uint64_t length = 1024;
 
   AlignedVector64<uint64_t> values =
-      GenerateInsecureUniformRandomValues(length, 0, modulus);
+      GenerateInsecureUniformRandomValues(length, min_value, max_value);
   EXPECT_EQ(values.size(), length);
-  EXPECT_TRUE(std::all_of(values.begin(), values.end(),
-                          [&](uint64_t x) { return x < modulus; }));
+  EXPECT_TRUE(std::all_of(values.begin(), values.end(), [&](uint64_t x) {
+    return (x >= min_value) && (x < max_value);
+  }));
   EXPECT_TRUE(std::any_of(values.begin(), values.end(),
-                          [&](uint64_t x) { return x = modulus - 1; }));
+                          [&](uint64_t x) { return x = min_value; }));
+  EXPECT_TRUE(std::any_of(values.begin(), values.end(),
+                          [&](uint64_t x) { return x == max_value - 1; }));
 }
 
 }  // namespace hexl


### PR DESCRIPTION
- Inlines BarrettReduce64 for improved performance on BM_EltwiseReduceModNative
- Adds minimum value to `GenerateInsecureUniformRandomValue` / `GenerateInsecureUniformRandomValues`
- Removes the `if (operand[i] >= modulus)` check from `hexl/eltwise/eltwise-reduce-mod.cpp` => ~10% speedup on vectors with all values >= modulus. In practice, we expect almost all the input values to EltwiseReduceMod to be >= modulus, so this is a better case to optimize for.