### PR TITLE
Fboemer/random bench

### DIFF
--- a/benchmark/bench-eltwise-add-mod.cpp
+++ b/benchmark/bench-eltwise-add-mod.cpp
@@ -11,6 +11,7 @@
 #include "hexl/logging/logging.hpp"
 #include "hexl/number-theory/number-theory.hpp"
 #include "hexl/util/aligned-allocator.hpp"
+#include "util/util-internal.hpp"
 
 namespace intel {
 namespace hexl {
@@ -21,8 +22,10 @@ static void BM_EltwiseVectorVectorAddModNative(
   size_t input_size = state.range(0);
   uint64_t modulus = 0xffffffffffc0001ULL;
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
-  AlignedVector64<uint64_t> input2(input_size, 2);
+  AlignedVector64<uint64_t> input1 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  AlignedVector64<uint64_t> input2 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   AlignedVector64<uint64_t> output(input_size, 0);
 
   for (auto _ : state) {
@@ -46,8 +49,10 @@ static void BM_EltwiseVectorVectorAddModAVX512(
   size_t input_size = state.range(0);
   size_t modulus = 1152921504606877697;
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
-  AlignedVector64<uint64_t> input2(input_size, 2);
+  AlignedVector64<uint64_t> input1 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  AlignedVector64<uint64_t> input2 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   AlignedVector64<uint64_t> output(input_size, 0);
 
   for (auto _ : state) {
@@ -70,8 +75,9 @@ static void BM_EltwiseVectorScalarAddModNative(
   size_t input_size = state.range(0);
   uint64_t modulus = 0xffffffffffc0001ULL;
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
-  uint64_t input2{2};
+  AlignedVector64<uint64_t> input1 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  uint64_t input2 = GenerateInsecureUniformRandomValue(0, modulus);
   AlignedVector64<uint64_t> output(input_size, 0);
 
   for (auto _ : state) {
@@ -95,8 +101,9 @@ static void BM_EltwiseVectorScalarAddModAVX512(
   size_t input_size = state.range(0);
   size_t modulus = 1152921504606877697;
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
-  uint64_t input2{2};
+  AlignedVector64<uint64_t> input1 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  uint64_t input2 = GenerateInsecureUniformRandomValue(0, modulus);
   AlignedVector64<uint64_t> output(input_size, 0);
 
   for (auto _ : state) {

--- a/benchmark/bench-eltwise-add-mod.cpp
+++ b/benchmark/bench-eltwise-add-mod.cpp
@@ -22,10 +22,8 @@ static void BM_EltwiseVectorVectorAddModNative(
   size_t input_size = state.range(0);
   uint64_t modulus = 0xffffffffffc0001ULL;
 
-  AlignedVector64<uint64_t> input1 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
-  AlignedVector64<uint64_t> input2 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input2 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   AlignedVector64<uint64_t> output(input_size, 0);
 
   for (auto _ : state) {
@@ -49,10 +47,8 @@ static void BM_EltwiseVectorVectorAddModAVX512(
   size_t input_size = state.range(0);
   size_t modulus = 1152921504606877697;
 
-  AlignedVector64<uint64_t> input1 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
-  AlignedVector64<uint64_t> input2 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input2 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   AlignedVector64<uint64_t> output(input_size, 0);
 
   for (auto _ : state) {
@@ -75,8 +71,7 @@ static void BM_EltwiseVectorScalarAddModNative(
   size_t input_size = state.range(0);
   uint64_t modulus = 0xffffffffffc0001ULL;
 
-  AlignedVector64<uint64_t> input1 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   uint64_t input2 = GenerateInsecureUniformRandomValue(0, modulus);
   AlignedVector64<uint64_t> output(input_size, 0);
 
@@ -101,8 +96,7 @@ static void BM_EltwiseVectorScalarAddModAVX512(
   size_t input_size = state.range(0);
   size_t modulus = 1152921504606877697;
 
-  AlignedVector64<uint64_t> input1 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   uint64_t input2 = GenerateInsecureUniformRandomValue(0, modulus);
   AlignedVector64<uint64_t> output(input_size, 0);
 

--- a/benchmark/bench-eltwise-fma-mod.cpp
+++ b/benchmark/bench-eltwise-fma-mod.cpp
@@ -23,8 +23,7 @@ static void BM_EltwiseFMAModAddNative(benchmark::State& state) {  //  NOLINT
   uint64_t modulus = 0xffffffffffc0001ULL;
   bool add = state.range(1);
 
-  AlignedVector64<uint64_t> input1 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   uint64_t input2 = GenerateInsecureUniformRandomValue(0, modulus);
   AlignedVector64<uint64_t> input3 =
       GenerateInsecureUniformRandomValues(input_size, 0, modulus);
@@ -48,8 +47,7 @@ static void BM_EltwiseFMAModAVX512DQ(benchmark::State& state) {  //  NOLINT
   size_t modulus = 100;
   bool add = state.range(1);
 
-  AlignedVector64<uint64_t> input1 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   uint64_t input2 = GenerateInsecureUniformRandomValue(0, modulus);
   AlignedVector64<uint64_t> input3 =
       GenerateInsecureUniformRandomValues(input_size, 0, modulus);
@@ -75,11 +73,9 @@ static void BM_EltwiseFMAModAVX512IFMA(benchmark::State& state) {  //  NOLINT
   size_t modulus = 100;
   bool add = state.range(1);
 
-  AlignedVector64<uint64_t> input1 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   uint64_t input2 = GenerateInsecureUniformRandomValue(0, modulus);
-  AlignedVector64<uint64_t> input3 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input3 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
 
   uint64_t* arg3 = add ? input3.data() : nullptr;
 

--- a/benchmark/bench-eltwise-fma-mod.cpp
+++ b/benchmark/bench-eltwise-fma-mod.cpp
@@ -11,6 +11,7 @@
 #include "hexl/logging/logging.hpp"
 #include "hexl/number-theory/number-theory.hpp"
 #include "hexl/util/aligned-allocator.hpp"
+#include "util/util-internal.hpp"
 
 namespace intel {
 namespace hexl {
@@ -22,9 +23,11 @@ static void BM_EltwiseFMAModAddNative(benchmark::State& state) {  //  NOLINT
   uint64_t modulus = 0xffffffffffc0001ULL;
   bool add = state.range(1);
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
-  uint64_t input2 = 1;
-  AlignedVector64<uint64_t> input3(input_size, 2);
+  AlignedVector64<uint64_t> input1 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  uint64_t input2 = GenerateInsecureUniformRandomValue(0, modulus);
+  AlignedVector64<uint64_t> input3 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   uint64_t* arg3 = add ? input3.data() : nullptr;
 
   for (auto _ : state) {
@@ -45,9 +48,11 @@ static void BM_EltwiseFMAModAVX512DQ(benchmark::State& state) {  //  NOLINT
   size_t modulus = 100;
   bool add = state.range(1);
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
-  uint64_t input2 = 3;
-  AlignedVector64<uint64_t> input3(input_size, 2);
+  AlignedVector64<uint64_t> input1 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  uint64_t input2 = GenerateInsecureUniformRandomValue(0, modulus);
+  AlignedVector64<uint64_t> input3 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
 
   uint64_t* arg3 = add ? input3.data() : nullptr;
 
@@ -70,9 +75,11 @@ static void BM_EltwiseFMAModAVX512IFMA(benchmark::State& state) {  //  NOLINT
   size_t modulus = 100;
   bool add = state.range(1);
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
-  uint64_t input2 = 3;
-  AlignedVector64<uint64_t> input3(input_size, 2);
+  AlignedVector64<uint64_t> input1 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  uint64_t input2 = GenerateInsecureUniformRandomValue(0, modulus);
+  AlignedVector64<uint64_t> input3 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
 
   uint64_t* arg3 = add ? input3.data() : nullptr;
 

--- a/benchmark/bench-eltwise-mult-mod.cpp
+++ b/benchmark/bench-eltwise-mult-mod.cpp
@@ -25,10 +25,8 @@ static void BM_EltwiseMultMod(benchmark::State& state) {  //  NOLINT
   size_t input_mod_factor = state.range(2);
   uint64_t modulus = (1ULL << bit_width) + 7;
 
-  AlignedVector64<uint64_t> input1 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
-  AlignedVector64<uint64_t> input2 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input2 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   AlignedVector64<uint64_t> output(input_size, 2);
 
   for (auto _ : state) {
@@ -48,10 +46,8 @@ static void BM_EltwiseMultModNative(benchmark::State& state) {  //  NOLINT
   size_t input_size = state.range(0);
   uint64_t modulus = 0xffffffffffc0001ULL;
 
-  AlignedVector64<uint64_t> input1 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
-  AlignedVector64<uint64_t> input2 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input2 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   AlignedVector64<uint64_t> output(input_size, 2);
 
   for (auto _ : state) {
@@ -76,10 +72,8 @@ static void BM_EltwiseMultModAVX512Float(benchmark::State& state) {  //  NOLINT
   size_t input_mod_factor = state.range(1);
   size_t modulus = 100;
 
-  AlignedVector64<uint64_t> input1 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
-  AlignedVector64<uint64_t> input2 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input2 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   AlignedVector64<uint64_t> output(input_size, 2);
 
   for (auto _ : state) {
@@ -115,10 +109,8 @@ static void BM_EltwiseMultModAVX512DQInt(benchmark::State& state) {  //  NOLINT
   size_t input_mod_factor = state.range(1);
   size_t modulus = 0xffffffffffc0001ULL;
 
-  AlignedVector64<uint64_t> input1 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
-  AlignedVector64<uint64_t> input2 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input2 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   AlignedVector64<uint64_t> output(input_size, 3);
 
   for (auto _ : state) {
@@ -153,10 +145,8 @@ static void BM_EltwiseMultModAVX512IFMAInt(
   size_t input_mod_factor = state.range(1);
   size_t modulus = 100;
 
-  AlignedVector64<uint64_t> input1 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
-  AlignedVector64<uint64_t> input2 =
-      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input2 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   AlignedVector64<uint64_t> output(input_size, 3);
 
   for (auto _ : state) {

--- a/benchmark/bench-eltwise-mult-mod.cpp
+++ b/benchmark/bench-eltwise-mult-mod.cpp
@@ -11,6 +11,7 @@
 #include "hexl/logging/logging.hpp"
 #include "hexl/number-theory/number-theory.hpp"
 #include "hexl/util/aligned-allocator.hpp"
+#include "util/util-internal.hpp"
 
 namespace intel {
 namespace hexl {
@@ -24,8 +25,10 @@ static void BM_EltwiseMultMod(benchmark::State& state) {  //  NOLINT
   size_t input_mod_factor = state.range(2);
   uint64_t modulus = (1ULL << bit_width) + 7;
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
-  AlignedVector64<uint64_t> input2(input_size, 2);
+  AlignedVector64<uint64_t> input1 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  AlignedVector64<uint64_t> input2 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   AlignedVector64<uint64_t> output(input_size, 2);
 
   for (auto _ : state) {
@@ -45,8 +48,10 @@ static void BM_EltwiseMultModNative(benchmark::State& state) {  //  NOLINT
   size_t input_size = state.range(0);
   uint64_t modulus = 0xffffffffffc0001ULL;
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
-  AlignedVector64<uint64_t> input2(input_size, 2);
+  AlignedVector64<uint64_t> input1 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  AlignedVector64<uint64_t> input2 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   AlignedVector64<uint64_t> output(input_size, 2);
 
   for (auto _ : state) {
@@ -71,8 +76,10 @@ static void BM_EltwiseMultModAVX512Float(benchmark::State& state) {  //  NOLINT
   size_t input_mod_factor = state.range(1);
   size_t modulus = 100;
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
-  AlignedVector64<uint64_t> input2(input_size, 2);
+  AlignedVector64<uint64_t> input1 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  AlignedVector64<uint64_t> input2 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   AlignedVector64<uint64_t> output(input_size, 2);
 
   for (auto _ : state) {
@@ -108,8 +115,10 @@ static void BM_EltwiseMultModAVX512DQInt(benchmark::State& state) {  //  NOLINT
   size_t input_mod_factor = state.range(1);
   size_t modulus = 0xffffffffffc0001ULL;
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
-  AlignedVector64<uint64_t> input2(input_size, 2);
+  AlignedVector64<uint64_t> input1 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  AlignedVector64<uint64_t> input2 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   AlignedVector64<uint64_t> output(input_size, 3);
 
   for (auto _ : state) {
@@ -144,8 +153,10 @@ static void BM_EltwiseMultModAVX512IFMAInt(
   size_t input_mod_factor = state.range(1);
   size_t modulus = 100;
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
-  AlignedVector64<uint64_t> input2(input_size, 2);
+  AlignedVector64<uint64_t> input1 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  AlignedVector64<uint64_t> input2 =
+      GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   AlignedVector64<uint64_t> output(input_size, 3);
 
   for (auto _ : state) {

--- a/benchmark/bench-eltwise-reduce-mod.cpp
+++ b/benchmark/bench-eltwise-reduce-mod.cpp
@@ -21,7 +21,7 @@ static void BM_EltwiseReduceModInPlace(benchmark::State& state) {  //  NOLINT
   size_t input_size = state.range(0);
   uint64_t modulus = 0xffffffffffc0001ULL;
 
-  AlignedVector64<uint64_t> input1 =
+  auto input1 =
       GenerateInsecureUniformRandomValues(input_size, 0, 100 * modulus);
   const uint64_t input_mod_factor = 0;
   const uint64_t output_mod_factor = 1;
@@ -44,7 +44,7 @@ static void BM_EltwiseReduceModCopy(benchmark::State& state) {  //  NOLINT
   size_t input_size = state.range(0);
   uint64_t modulus = 0xffffffffffc0001ULL;
 
-  AlignedVector64<uint64_t> input1 =
+  auto input1 =
       GenerateInsecureUniformRandomValues(input_size, 0, 100 * modulus);
   const uint64_t input_mod_factor = 0;
   const uint64_t output_mod_factor = 1;
@@ -69,7 +69,7 @@ static void BM_EltwiseReduceModNative(benchmark::State& state) {  //  NOLINT
   size_t input_size = state.range(0);
   uint64_t modulus = 0xffffffffffc0001ULL;
 
-  AlignedVector64<uint64_t> input1 =
+  auto input1 =
       GenerateInsecureUniformRandomValues(input_size, 0, 100 * modulus);
   const uint64_t input_mod_factor = 0;
   const uint64_t output_mod_factor = 1;
@@ -95,7 +95,7 @@ static void BM_EltwiseReduceModAVX512(benchmark::State& state) {  //  NOLINT
   size_t input_size = state.range(0);
   size_t modulus = 1152921504606877697;
 
-  AlignedVector64<uint64_t> input1 =
+  auto input1 =
       GenerateInsecureUniformRandomValues(input_size, 0, 100 * modulus);
   const uint64_t input_mod_factor = 0;
   const uint64_t output_mod_factor = 1;

--- a/benchmark/bench-eltwise-sub-mod.cpp
+++ b/benchmark/bench-eltwise-sub-mod.cpp
@@ -11,6 +11,7 @@
 #include "hexl/logging/logging.hpp"
 #include "hexl/number-theory/number-theory.hpp"
 #include "hexl/util/aligned-allocator.hpp"
+#include "util/util-internal.hpp"
 
 namespace intel {
 namespace hexl {
@@ -21,8 +22,8 @@ static void BM_EltwiseVectorVectorSubModNative(
   size_t input_size = state.range(0);
   uint64_t modulus = 0xffffffffffc0001ULL;
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
-  AlignedVector64<uint64_t> input2(input_size, 2);
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input2 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   AlignedVector64<uint64_t> output(input_size, 0);
 
   for (auto _ : state) {
@@ -46,8 +47,8 @@ static void BM_EltwiseVectorVectorSubModAVX512(
   size_t input_size = state.range(0);
   size_t modulus = 1152921504606877697;
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
-  AlignedVector64<uint64_t> input2(input_size, 2);
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  auto input2 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
   AlignedVector64<uint64_t> output(input_size, 0);
 
   for (auto _ : state) {
@@ -70,8 +71,8 @@ static void BM_EltwiseVectorScalarSubModNative(
   size_t input_size = state.range(0);
   uint64_t modulus = 0xffffffffffc0001ULL;
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
-  uint64_t input2{2};
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  uint64_t input2 = GenerateInsecureUniformRandomValue(0, modulus);
   AlignedVector64<uint64_t> output(input_size, 0);
 
   for (auto _ : state) {
@@ -95,8 +96,8 @@ static void BM_EltwiseVectorScalarSubModAVX512(
   size_t input_size = state.range(0);
   size_t modulus = 1152921504606877697;
 
-  AlignedVector64<uint64_t> input1(input_size, 1);
-  uint64_t input2{2};
+  auto input1 = GenerateInsecureUniformRandomValues(input_size, 0, modulus);
+  uint64_t input2 = GenerateInsecureUniformRandomValue(0, modulus);
   AlignedVector64<uint64_t> output(input_size, 0);
 
   for (auto _ : state) {

--- a/benchmark/bench-ntt.cpp
+++ b/benchmark/bench-ntt.cpp
@@ -12,6 +12,7 @@
 #include "ntt/fwd-ntt-avx512.hpp"
 #include "ntt/inv-ntt-avx512.hpp"
 #include "ntt/ntt-internal.hpp"
+#include "util/util-internal.hpp"
 
 namespace intel {
 namespace hexl {
@@ -24,7 +25,7 @@ static void BM_FwdNTTNativeRadix2(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
   size_t modulus = GeneratePrimes(1, 45, true, ntt_size)[0];
 
-  AlignedVector64<uint64_t> input(ntt_size, 1);
+  auto input = GenerateInsecureUniformRandomValues(ntt_size, 0, modulus);
   NTT ntt(ntt_size, modulus);
 
   for (auto _ : state) {
@@ -45,7 +46,7 @@ static void BM_FwdNTTNativeRadix4(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
   size_t modulus = GeneratePrimes(1, 45, true, ntt_size)[0];
 
-  AlignedVector64<uint64_t> input(ntt_size, 1);
+  auto input = GenerateInsecureUniformRandomValues(ntt_size, 0, modulus);
   NTT ntt(ntt_size, modulus);
 
   for (auto _ : state) {
@@ -69,7 +70,7 @@ static void BM_FwdNTT_AVX512IFMA(benchmark::State& state) {  //  NOLINT
   size_t modulus_bits = 49;
   size_t modulus = GeneratePrimes(1, modulus_bits, true, ntt_size)[0];
 
-  AlignedVector64<uint64_t> input(ntt_size, 1);
+  auto input = GenerateInsecureUniformRandomValues(ntt_size, 0, modulus);
   NTT ntt(ntt_size, modulus);
 
   const AlignedVector64<uint64_t> root_of_unity =
@@ -98,7 +99,7 @@ static void BM_FwdNTT_AVX512IFMALazy(benchmark::State& state) {  //  NOLINT
   size_t modulus_bits = 49;
   size_t modulus = GeneratePrimes(1, modulus_bits, true, ntt_size)[0];
 
-  AlignedVector64<uint64_t> input(ntt_size, 1);
+  auto input = GenerateInsecureUniformRandomValues(ntt_size, 0, modulus);
   NTT ntt(ntt_size, modulus);
 
   const AlignedVector64<uint64_t> root_of_unity =
@@ -134,7 +135,7 @@ static void BM_FwdNTT_AVX512DQ_32(benchmark::State& state) {  //  NOLINT
   size_t modulus_bits = 29;
   size_t modulus = GeneratePrimes(1, modulus_bits, true, ntt_size)[0];
 
-  AlignedVector64<uint64_t> input(ntt_size, 1);
+  auto input = GenerateInsecureUniformRandomValues(ntt_size, 0, modulus);
   NTT ntt(ntt_size, modulus);
 
   const AlignedVector64<uint64_t> root_of_unity =
@@ -165,7 +166,7 @@ static void BM_FwdNTT_AVX512DQ_64(benchmark::State& state) {  //  NOLINT
   size_t modulus_bits = 55;
   size_t modulus = GeneratePrimes(1, modulus_bits, true, ntt_size)[0];
 
-  AlignedVector64<uint64_t> input(ntt_size, 1);
+  auto input = GenerateInsecureUniformRandomValues(ntt_size, 0, modulus);
   NTT ntt(ntt_size, modulus);
 
   const AlignedVector64<uint64_t> root_of_unity =
@@ -197,7 +198,7 @@ static void BM_FwdNTTInPlace(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
   size_t modulus = GeneratePrimes(1, 61, true, ntt_size)[0];
 
-  AlignedVector64<uint64_t> input(ntt_size, 1);
+  auto input = GenerateInsecureUniformRandomValues(ntt_size, 0, modulus);
   NTT ntt(ntt_size, modulus);
 
   for (auto _ : state) {
@@ -218,7 +219,7 @@ static void BM_FwdNTTCopy(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
   size_t modulus = GeneratePrimes(1, 45, true, ntt_size)[0];
 
-  AlignedVector64<uint64_t> input(ntt_size, 1);
+  auto input = GenerateInsecureUniformRandomValues(ntt_size, 0, modulus);
   AlignedVector64<uint64_t> output(ntt_size, 1);
   NTT ntt(ntt_size, modulus);
 
@@ -238,7 +239,7 @@ static void BM_InvNTTCopy(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
   size_t modulus = GeneratePrimes(1, 45, true, ntt_size)[0];
 
-  AlignedVector64<uint64_t> input(ntt_size, 1);
+  auto input = GenerateInsecureUniformRandomValues(ntt_size, 0, modulus);
   AlignedVector64<uint64_t> output(ntt_size, 1);
   NTT ntt(ntt_size, modulus);
 
@@ -261,7 +262,7 @@ static void BM_InvNTTNativeRadix2(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
   size_t modulus = GeneratePrimes(1, 45, true, ntt_size)[0];
 
-  AlignedVector64<uint64_t> input(ntt_size, 1);
+  auto input = GenerateInsecureUniformRandomValues(ntt_size, 0, modulus);
   NTT ntt(ntt_size, modulus);
 
   const AlignedVector64<uint64_t> root_of_unity = ntt.GetInvRootOfUnityPowers();
@@ -286,7 +287,7 @@ static void BM_InvNTTNativeRadix4(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
   size_t modulus = GeneratePrimes(1, 45, true, ntt_size)[0];
 
-  AlignedVector64<uint64_t> input(ntt_size, 1);
+  auto input = GenerateInsecureUniformRandomValues(ntt_size, 0, modulus);
   NTT ntt(ntt_size, modulus);
 
   const AlignedVector64<uint64_t> root_of_unity = ntt.GetInvRootOfUnityPowers();
@@ -313,7 +314,7 @@ static void BM_InvNTT_AVX512IFMA(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
   size_t modulus = GeneratePrimes(1, 49, true, ntt_size)[0];
 
-  AlignedVector64<uint64_t> input(ntt_size, 1);
+  auto input = GenerateInsecureUniformRandomValues(ntt_size, 0, modulus);
   NTT ntt(ntt_size, modulus);
 
   const AlignedVector64<uint64_t> root_of_unity = ntt.GetInvRootOfUnityPowers();
@@ -339,7 +340,7 @@ static void BM_InvNTT_AVX512IFMALazy(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
   size_t modulus = GeneratePrimes(1, 49, true, ntt_size)[0];
 
-  AlignedVector64<uint64_t> input(ntt_size, 1);
+  auto input = GenerateInsecureUniformRandomValues(ntt_size, 0, modulus);
   NTT ntt(ntt_size, modulus);
 
   const AlignedVector64<uint64_t> root_of_unity = ntt.GetInvRootOfUnityPowers();
@@ -369,7 +370,7 @@ static void BM_InvNTT_AVX512DQ_32(benchmark::State& state) {  //  NOLINT
   uint64_t output_mod_factor = state.range(1);
   size_t modulus = GeneratePrimes(1, 30, true, ntt_size)[0];
 
-  AlignedVector64<uint64_t> input(ntt_size, 1);
+  auto input = GenerateInsecureUniformRandomValues(ntt_size, 0, modulus);
   NTT ntt(ntt_size, modulus);
 
   const AlignedVector64<uint64_t> root_of_unity = ntt.GetInvRootOfUnityPowers();
@@ -397,7 +398,7 @@ static void BM_InvNTT_AVX512DQ_64(benchmark::State& state) {  //  NOLINT
   uint64_t output_mod_factor = state.range(1);
   size_t modulus = GeneratePrimes(1, 61, true, ntt_size)[0];
 
-  AlignedVector64<uint64_t> input(ntt_size, 1);
+  auto input = GenerateInsecureUniformRandomValues(ntt_size, 0, modulus);
   NTT ntt(ntt_size, modulus);
 
   const AlignedVector64<uint64_t> root_of_unity = ntt.GetInvRootOfUnityPowers();


### PR DESCRIPTION
Use random input values for benchmarks. No performance difference observed, but this more accurately reflects expected usage.