### PR TITLE
Remove Intel workflow

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -41,7 +41,6 @@ jobs:
   format:
     name: Format
     runs-on: ubuntu-20.04
-    environment: intel_workflow
     steps:
       - uses: actions/checkout@v2
       # Required for pre-commit
@@ -54,7 +53,6 @@ jobs:
   coverage-build:
     name: coverage-build
     runs-on: ubuntu-20.04
-    environment: intel_workflow
     defaults:
       run:
         shell: bash
@@ -94,7 +92,6 @@ jobs:
   nix-build:
     name: '${{ matrix.os }} ${{ matrix.build_type }} shared=${{ matrix.shared_lib }}'
     runs-on: '${{ matrix.os }}'
-    environment: intel_workflow
     defaults:
       run:
         shell: bash
@@ -185,7 +182,6 @@ jobs:
   windows-build:
     name: 'Windows ${{ matrix.os }} ${{ matrix.build_type }} shared=${{ matrix.shared_lib }}'
     runs-on: windows-latest
-    environment: intel_workflow
     defaults:
       run:
         shell: bash
@@ -221,7 +217,6 @@ jobs:
   experimental-build:
     name: 'experimental: ${{ matrix.os }} ${{ matrix.build_type }} shared=${{ matrix.shared_lib }}'
     runs-on: '${{ matrix.os }}'
-    environment: intel_workflow
     defaults:
       run:
         shell: bash

--- a/.github/workflows/klocwork.yml
+++ b/.github/workflows/klocwork.yml
@@ -13,7 +13,6 @@ jobs:
   klocwork:
     name: klocwork scan
     runs-on: [self-hosted, Linux, X64, ice-lake]
-    environment: intel_workflow
     steps:
       - uses: actions/checkout@v2
       - name: Setup


### PR DESCRIPTION
See https://github.com/intel/hexl/pull/70 for an example of an external collaborator requiring approval to run the workflow after this change.

This PR's  workflow didn't require any approval to run, which is the desired behavior since I have write permission to the repo.

![MicrosoftTeams-image (4)](https://user-images.githubusercontent.com/7935794/134747419-b5b5b582-0a29-4a4c-8b8a-f17d4401bf4d.png)