### PR TITLE
Fboemer/fix 32 bit invntt

### DIFF
--- a/benchmark/bench-ntt.cpp
+++ b/benchmark/bench-ntt.cpp
@@ -368,7 +368,7 @@ BENCHMARK(BM_InvNTT_AVX512IFMALazy)
 static void BM_InvNTT_AVX512DQ_32(benchmark::State& state) {  //  NOLINT
   size_t ntt_size = state.range(0);
   uint64_t output_mod_factor = state.range(1);
-  size_t modulus = GeneratePrimes(1, 30, true, ntt_size)[0];
+  size_t modulus = GeneratePrimes(1, 29, true, ntt_size)[0];
 
   auto input = GenerateInsecureUniformRandomValues(ntt_size, 0, modulus);
   NTT ntt(ntt_size, modulus);

--- a/hexl/include/hexl/ntt/ntt.hpp
+++ b/hexl/include/hexl/ntt/ntt.hpp
@@ -212,7 +212,7 @@ class NTT {
 
   /// @brief Maximum modulus to use 32-bit AVX512-DQ acceleration for the
   /// inverse transform
-  static const size_t s_max_inv_32_modulus{1ULL << (32 - 1)};
+  static const size_t s_max_inv_32_modulus{1ULL << (32 - 2)};
 
   /// @brief Maximum modulus to use AVX512-IFMA acceleration for the forward
   /// transform
@@ -220,7 +220,35 @@ class NTT {
 
   /// @brief Maximum modulus to use AVX512-IFMA acceleration for the inverse
   /// transform
-  static const size_t s_max_inv_ifma_modulus{1ULL << (s_ifma_shift_bits - 1)};
+  static const size_t s_max_inv_ifma_modulus{1ULL << (s_ifma_shift_bits - 2)};
+
+  /// @brief Maximum modulus to use AVX512-DQ acceleration for the inverse
+  /// transform
+  static const size_t s_max_inv_dq_modulus{1ULL << (s_default_shift_bits - 2)};
+
+  static size_t s_max_fwd_modulus(int bit_shift) {
+    if (bit_shift == 32) {
+      return s_max_fwd_32_modulus;
+    } else if (bit_shift == 52) {
+      return s_max_fwd_ifma_modulus;
+    } else if (bit_shift == 64) {
+      return 1ULL << MaxModulusBits();
+    }
+    HEXL_CHECK(false, "Invalid bit_shift " << bit_shift);
+    return 0;
+  }
+
+  static size_t s_max_inv_modulus(int bit_shift) {
+    if (bit_shift == 32) {
+      return s_max_inv_32_modulus;
+    } else if (bit_shift == 52) {
+      return s_max_inv_ifma_modulus;
+    } else if (bit_shift == 64) {
+      return 1ULL << MaxModulusBits();
+    }
+    HEXL_CHECK(false, "Invalid bit_shift " << bit_shift);
+    return 0;
+  }
 
  private:
   void ComputeRootOfUnityPowers();

--- a/hexl/include/hexl/util/aligned-allocator.hpp
+++ b/hexl/include/hexl/util/aligned-allocator.hpp
@@ -40,8 +40,8 @@ class AlignedAllocator {
   explicit AlignedAllocator(AllocatorStrategyPtr strategy = nullptr) noexcept
       : m_alloc_impl((strategy != nullptr) ? strategy : mallocStrategy) {}
 
-  AlignedAllocator(const AlignedAllocator& src)
-      : m_alloc_impl(src.m_alloc_impl) {}
+  AlignedAllocator(const AlignedAllocator& src) = default;
+  AlignedAllocator& operator=(const AlignedAllocator& src) = default;
 
   template <typename U>
   AlignedAllocator(const AlignedAllocator<U, Alignment>& src)

--- a/hexl/ntt/fwd-ntt-avx512.cpp
+++ b/hexl/ntt/fwd-ntt-avx512.cpp
@@ -1,14 +1,13 @@
 // Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ntt/fwd-ntt-avx512.hpp"
-
 #include <functional>
 #include <vector>
 
 #include "hexl/logging/logging.hpp"
 #include "hexl/ntt/ntt.hpp"
 #include "hexl/number-theory/number-theory.hpp"
+#include "ntt/fwd-ntt-avx512.hpp"
 #include "ntt/ntt-avx512-util.hpp"
 #include "ntt/ntt-internal.hpp"
 #include "util/avx512-util.hpp"
@@ -223,9 +222,10 @@ void ForwardTransformToBitReverseAVX512(
     uint64_t output_mod_factor, uint64_t recursion_depth,
     uint64_t recursion_half) {
   HEXL_CHECK(NTT::CheckArguments(n, modulus), "");
-  HEXL_CHECK(modulus < MaximumValue(BitShift) / 4,
+  HEXL_CHECK(modulus < NTT::s_max_fwd_modulus(BitShift),
              "modulus " << modulus << " too large for BitShift " << BitShift
-                        << " => maximum value " << MaximumValue(BitShift) / 4);
+                        << " => maximum value "
+                        << NTT::s_max_fwd_modulus(BitShift));
   HEXL_CHECK_BOUNDS(precon_root_of_unity_powers, n, MaximumValue(BitShift),
                     "precon_root_of_unity_powers too large");
   HEXL_CHECK_BOUNDS(operand, n, MaximumValue(BitShift), "operand too large");

--- a/hexl/ntt/fwd-ntt-avx512.cpp
+++ b/hexl/ntt/fwd-ntt-avx512.cpp
@@ -1,13 +1,14 @@
 // Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ntt/fwd-ntt-avx512.hpp"
+
 #include <functional>
 #include <vector>
 
 #include "hexl/logging/logging.hpp"
 #include "hexl/ntt/ntt.hpp"
 #include "hexl/number-theory/number-theory.hpp"
-#include "ntt/fwd-ntt-avx512.hpp"
 #include "ntt/ntt-avx512-util.hpp"
 #include "ntt/ntt-internal.hpp"
 #include "util/avx512-util.hpp"

--- a/hexl/ntt/inv-ntt-avx512.cpp
+++ b/hexl/ntt/inv-ntt-avx512.cpp
@@ -1,8 +1,6 @@
 // Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ntt/inv-ntt-avx512.hpp"
-
 #include <immintrin.h>
 
 #include <functional>
@@ -11,6 +9,7 @@
 #include "hexl/logging/logging.hpp"
 #include "hexl/ntt/ntt.hpp"
 #include "hexl/number-theory/number-theory.hpp"
+#include "ntt/inv-ntt-avx512.hpp"
 #include "ntt/ntt-avx512-util.hpp"
 #include "ntt/ntt-internal.hpp"
 #include "util/avx512-util.hpp"
@@ -227,9 +226,10 @@ void InverseTransformFromBitReverseAVX512(
              "InverseTransformFromBitReverseAVX512 doesn't support small "
              "transforms. Need n >= 16, got n = "
                  << n);
-  HEXL_CHECK(modulus < MaximumValue(BitShift) / 2,
+  HEXL_CHECK(modulus < NTT::s_max_inv_modulus(BitShift),
              "modulus " << modulus << " too large for BitShift " << BitShift
-                        << " => maximum value " << MaximumValue(BitShift) / 2);
+                        << " => maximum value "
+                        << NTT::s_max_inv_modulus(BitShift));
   HEXL_CHECK_BOUNDS(precon_inv_root_of_unity_powers, n, MaximumValue(BitShift),
                     "precon_inv_root_of_unity_powers too large");
   HEXL_CHECK_BOUNDS(operand, n, MaximumValue(BitShift), "operand too large");

--- a/hexl/ntt/inv-ntt-avx512.cpp
+++ b/hexl/ntt/inv-ntt-avx512.cpp
@@ -1,6 +1,8 @@
 // Copyright (C) 2020-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#include "ntt/inv-ntt-avx512.hpp"
+
 #include <immintrin.h>
 
 #include <functional>
@@ -9,7 +11,6 @@
 #include "hexl/logging/logging.hpp"
 #include "hexl/ntt/ntt.hpp"
 #include "hexl/number-theory/number-theory.hpp"
-#include "ntt/inv-ntt-avx512.hpp"
 #include "ntt/ntt-avx512-util.hpp"
 #include "ntt/ntt-internal.hpp"
 #include "util/avx512-util.hpp"

--- a/hexl/ntt/ntt-default.hpp
+++ b/hexl/ntt/ntt-default.hpp
@@ -101,6 +101,9 @@ inline void FwdButterflyRadix4(uint64_t* X0, uint64_t* X1, uint64_t* X2,
 inline void InvButterflyRadix2(uint64_t* X, uint64_t* Y, uint64_t W,
                                uint64_t W_precon, uint64_t modulus,
                                uint64_t twice_modulus) {
+  HEXL_VLOG(4, "InvButterflyRadix2 X " << *X << ", Y " << *Y << " W " << W
+                                       << " W_precon " << W_precon
+                                       << " modulus " << modulus);
   uint64_t tx = *X + *Y;
   uint64_t ty = *X + twice_modulus - *Y;
 

--- a/hexl/ntt/ntt-default.hpp
+++ b/hexl/ntt/ntt-default.hpp
@@ -101,9 +101,6 @@ inline void FwdButterflyRadix4(uint64_t* X0, uint64_t* X1, uint64_t* X2,
 inline void InvButterflyRadix2(uint64_t* X, uint64_t* Y, uint64_t W,
                                uint64_t W_precon, uint64_t modulus,
                                uint64_t twice_modulus) {
-  HEXL_VLOG(4, "InvButterflyRadix2 X " << *X << ", Y " << *Y << " W " << W
-                                       << " W_precon " << W_precon
-                                       << " modulus " << modulus);
   uint64_t tx = *X + *Y;
   uint64_t ty = *X + twice_modulus - *Y;
 

--- a/test/test-ntt-avx512.cpp
+++ b/test/test-ntt-avx512.cpp
@@ -166,8 +166,10 @@ TEST(NTT, WriteInvInterleavedT4) {
   AssertEqual(exp, out);
 }
 
+class NttAVX512Test : public DegreeModulusBoolTest {};
+
 #ifdef HEXL_HAS_AVX512IFMA
-TEST_P(DegreeModulusBoolTest, FwdNTT_AVX512IFMA) {
+TEST_P(NttAVX512Test, FwdNTT_AVX512IFMA) {
   if (!has_avx512dq || (m_modulus >= NTT::s_max_fwd_modulus(52))) {
     GTEST_SKIP();
   }
@@ -203,7 +205,7 @@ TEST_P(DegreeModulusBoolTest, FwdNTT_AVX512IFMA) {
   }
 }
 
-TEST_P(DegreeModulusBoolTest, InvNTT_AVX512IFMA) {
+TEST_P(NttAVX512Test, InvNTT_AVX512IFMA) {
   if (!has_avx512dq || (m_modulus >= NTT::s_max_fwd_modulus(52))) {
     GTEST_SKIP();
   }
@@ -241,7 +243,7 @@ TEST_P(DegreeModulusBoolTest, InvNTT_AVX512IFMA) {
 #endif
 
 // Checks AVX512 and native forward NTT implementations match
-TEST_P(DegreeModulusBoolTest, FwdNTT_AVX512_32) {
+TEST_P(NttAVX512Test, FwdNTT_AVX512_32) {
   if (!has_avx512dq || (m_modulus >= NTT::s_max_fwd_modulus(32))) {
     GTEST_SKIP();
   }
@@ -276,7 +278,7 @@ TEST_P(DegreeModulusBoolTest, FwdNTT_AVX512_32) {
 }
 
 // Checks AVX512 and native forward NTT implementations match
-TEST_P(DegreeModulusBoolTest, FwdNTT_AVX512_64) {
+TEST_P(NttAVX512Test, FwdNTT_AVX512_64) {
   if (!has_avx512dq || (m_modulus >= NTT::s_max_fwd_modulus(64))) {
     GTEST_SKIP();
   }
@@ -311,7 +313,7 @@ TEST_P(DegreeModulusBoolTest, FwdNTT_AVX512_64) {
 }
 
 // Checks 32-bit AVX512 and native InvNTT implementations match
-TEST_P(DegreeModulusBoolTest, InvNTT_AVX512_32) {
+TEST_P(NttAVX512Test, InvNTT_AVX512_32) {
   if (!has_avx512dq || (m_modulus >= NTT::s_max_inv_modulus(32))) {
     GTEST_SKIP();
   }
@@ -347,7 +349,7 @@ TEST_P(DegreeModulusBoolTest, InvNTT_AVX512_32) {
 }
 
 // Checks 64-bit AVX512 and native InvNTT implementations match
-TEST_P(DegreeModulusBoolTest, InvNTT_AVX512_64) {
+TEST_P(NttAVX512Test, InvNTT_AVX512_64) {
   if (!has_avx512dq || (m_modulus >= NTT::s_max_inv_modulus(64))) {
     GTEST_SKIP();
   }
@@ -383,7 +385,7 @@ TEST_P(DegreeModulusBoolTest, InvNTT_AVX512_64) {
 #endif
 
 INSTANTIATE_TEST_SUITE_P(
-    NTT_AVX512, DegreeModulusBoolTest,
+    NTT, NttAVX512Test,
     ::testing::Combine(::testing::ValuesIn(AlignedVector64<uint64_t>{
                            1 << 11, 1 << 12, 1 << 13}),
                        ::testing::ValuesIn(AlignedVector64<uint64_t>{

--- a/test/test-ntt-avx512.cpp
+++ b/test/test-ntt-avx512.cpp
@@ -6,13 +6,13 @@
 #include <tuple>
 #include <vector>
 
-#include "hexl/logging/logging.hpp"
 #include "hexl/ntt/ntt.hpp"
 #include "hexl/number-theory/number-theory.hpp"
 #include "ntt/fwd-ntt-avx512.hpp"
 #include "ntt/inv-ntt-avx512.hpp"
 #include "ntt/ntt-avx512-util.hpp"
 #include "ntt/ntt-internal.hpp"
+#include "test-ntt-util.hpp"
 #include "test-util.hpp"
 #include "util/cpu-features.hpp"
 
@@ -167,58 +167,35 @@ TEST(NTT, WriteInvInterleavedT4) {
 }
 
 #ifdef HEXL_HAS_AVX512IFMA
-// First parameter is the NTT degree
-// Second parameter is the number of bits in the NTT modulus
-// Third parameter is whether or not to prefer small primes
-class DegreeModulusBoolTest
-    : public ::testing::TestWithParam<std::tuple<uint64_t, uint64_t, bool>> {
- protected:
-  void SetUp() {}
-
-  void TearDown() {}
-
- public:
-};
-
-TEST_P(DegreeModulusBoolTest, FwdNTTAVX512IFMA) {
-  if (!has_avx512ifma) {
+TEST_P(DegreeModulusBoolTest, FwdNTT_AVX512IFMA) {
+  if (!has_avx512dq || (m_modulus >= NTT::s_max_fwd_modulus(52))) {
     GTEST_SKIP();
   }
-  uint64_t N = std::get<0>(GetParam());
-  uint64_t modulus_bits = std::get<1>(GetParam());
-  bool prefer_small_primes = std::get<2>(GetParam());
-  uint64_t modulus = GeneratePrimes(1, modulus_bits, prefer_small_primes, N)[0];
 
-#ifdef HEXL_DEBUG
-  size_t num_trials = 1;
-#else
-  size_t num_trials = 20;
-#endif
-
-  for (size_t trial = 0; trial < num_trials; ++trial) {
+  for (size_t trial = 0; trial < m_num_trials; ++trial) {
     AlignedVector64<uint64_t> input64 =
-        GenerateInsecureUniformRandomValues(N, 0, modulus);
+        GenerateInsecureUniformRandomValues(m_N, 0, m_modulus);
     AlignedVector64<uint64_t> input_ifma = input64;
     AlignedVector64<uint64_t> input_ifma_lazy = input64;
-    AlignedVector64<uint64_t> exp_output(N, 0);
+    AlignedVector64<uint64_t> exp_output(m_N, 0);
 
     // Compute reference
-    NTT ntt64(N, modulus);
-    ReferenceForwardTransformToBitReverse(input64.data(), N, modulus,
-                                          ntt64.GetRootOfUnityPowers().data());
+
+    ReferenceForwardTransformToBitReverse(input64.data(), m_N, m_modulus,
+                                          m_ntt.GetRootOfUnityPowers().data());
 
     ForwardTransformToBitReverseAVX512<52>(
-        input_ifma.data(), N, ntt64.GetModulus(),
-        ntt64.GetAVX512RootOfUnityPowers().data(),
-        ntt64.GetAVX512Precon52RootOfUnityPowers().data(), 1, 1);
+        input_ifma.data(), m_N, m_ntt.GetModulus(),
+        m_ntt.GetAVX512RootOfUnityPowers().data(),
+        m_ntt.GetAVX512Precon52RootOfUnityPowers().data(), 1, 1);
 
     // Compute lazy
     ForwardTransformToBitReverseAVX512<52>(
-        input_ifma_lazy.data(), N, ntt64.GetModulus(),
-        ntt64.GetAVX512RootOfUnityPowers().data(),
-        ntt64.GetAVX512Precon52RootOfUnityPowers().data(), 2, 4);
+        input_ifma_lazy.data(), m_N, m_ntt.GetModulus(),
+        m_ntt.GetAVX512RootOfUnityPowers().data(),
+        m_ntt.GetAVX512Precon52RootOfUnityPowers().data(), 2, 4);
     for (auto& elem : input_ifma_lazy) {
-      elem = elem % modulus;
+      elem = elem % m_modulus;
     }
 
     AssertEqual(input64, input_ifma);
@@ -226,253 +203,193 @@ TEST_P(DegreeModulusBoolTest, FwdNTTAVX512IFMA) {
   }
 }
 
-TEST_P(DegreeModulusBoolTest, InvNTTAVX512IFMA) {
-  if (!has_avx512ifma) {
+TEST_P(DegreeModulusBoolTest, InvNTT_AVX512IFMA) {
+  if (!has_avx512dq || (m_modulus >= NTT::s_max_fwd_modulus(52))) {
     GTEST_SKIP();
   }
-  uint64_t N = std::get<0>(GetParam());
-  uint64_t modulus_bits = std::get<1>(GetParam());
-  bool prefer_small_primes = std::get<2>(GetParam());
-  uint64_t modulus = GeneratePrimes(1, modulus_bits, prefer_small_primes, N)[0];
 
-#ifdef HEXL_DEBUG
-  size_t num_trials = 1;
-#else
-  size_t num_trials = 20;
-#endif
-
-  for (size_t trial = 0; trial < num_trials; ++trial) {
+  for (size_t trial = 0; trial < m_num_trials; ++trial) {
     AlignedVector64<uint64_t> input64 =
-        GenerateInsecureUniformRandomValues(N, 0, modulus);
+        GenerateInsecureUniformRandomValues(m_N, 0, m_modulus);
     AlignedVector64<uint64_t> input_ifma = input64;
     AlignedVector64<uint64_t> input_ifma_lazy = input64;
-
-    AlignedVector64<uint64_t> exp_output(N, 0);
+    AlignedVector64<uint64_t> exp_output(m_N, 0);
 
     // Compute reference
-    NTT ntt(N, modulus);
     InverseTransformFromBitReverseRadix2(
-        input64.data(), N, modulus, ntt.GetInvRootOfUnityPowers().data(),
-        ntt.GetPrecon64InvRootOfUnityPowers().data(), 1, 1);
+        input64.data(), m_N, m_modulus, m_ntt.GetInvRootOfUnityPowers().data(),
+        m_ntt.GetPrecon64InvRootOfUnityPowers().data(), 1, 1);
 
     InverseTransformFromBitReverseAVX512<52>(
-        input_ifma.data(), N, ntt.GetModulus(),
-        ntt.GetInvRootOfUnityPowers().data(),
-        ntt.GetPrecon52InvRootOfUnityPowers().data(), 1, 1);
+        input_ifma.data(), m_N, m_ntt.GetModulus(),
+        m_ntt.GetInvRootOfUnityPowers().data(),
+        m_ntt.GetPrecon52InvRootOfUnityPowers().data(), 1, 1);
 
     // Compute lazy
     InverseTransformFromBitReverseAVX512<52>(
-        input_ifma_lazy.data(), N, ntt.GetModulus(),
-        ntt.GetInvRootOfUnityPowers().data(),
-        ntt.GetPrecon52InvRootOfUnityPowers().data(), 1, 2);
+        input_ifma_lazy.data(), m_N, m_ntt.GetModulus(),
+        m_ntt.GetInvRootOfUnityPowers().data(),
+        m_ntt.GetPrecon52InvRootOfUnityPowers().data(), 1, 2);
     for (auto& elem : input_ifma_lazy) {
-      elem = elem % modulus;
+      elem = elem % m_modulus;
     }
 
     AssertEqual(input64, input_ifma);
     AssertEqual(input64, input_ifma_lazy);
   }
 }
-
-// Test modulus around 50 bits to check IFMA behavior
-INSTANTIATE_TEST_SUITE_P(
-    NTT, DegreeModulusBoolTest,
-    ::testing::Combine(::testing::ValuesIn(AlignedVector64<uint64_t>{
-                           1 << 11, 1 << 12, 1 << 13}),
-                       ::testing::ValuesIn(AlignedVector64<uint64_t>{48, 49}),
-                       ::testing::ValuesIn(std::vector<bool>{false, true})));
-
 #endif
 
 // Checks AVX512 and native forward NTT implementations match
-TEST(NTT, FwdNTT_AVX512_32) {
-  if (!has_avx512dq) {
+TEST_P(DegreeModulusBoolTest, FwdNTT_AVX512_32) {
+  if (!has_avx512dq || (m_modulus >= NTT::s_max_fwd_modulus(32))) {
     GTEST_SKIP();
   }
 
-#ifdef HEXL_DEBUG
-  size_t num_trials = 1;
-#else
-  size_t num_trials = 20;
-#endif
+  for (size_t trial = 0; trial < m_num_trials; ++trial) {
+    AlignedVector64<uint64_t> input =
+        GenerateInsecureUniformRandomValues(m_N, 0, m_modulus);
+    AlignedVector64<uint64_t> input_avx = input;
+    AlignedVector64<uint64_t> input_avx_lazy = input;
 
-  for (size_t N = 512; N <= 65536; N *= 2) {
-    uint64_t modulus = GeneratePrimes(1, 27, true, N)[0];
+    ForwardTransformToBitReverseRadix2(
+        input.data(), m_N, m_modulus, m_ntt.GetRootOfUnityPowers().data(),
+        m_ntt.GetPrecon64RootOfUnityPowers().data(), 2, 1);
 
-    NTT ntt(N, modulus);
+    ForwardTransformToBitReverseAVX512<32>(
+        input_avx.data(), m_N, m_ntt.GetModulus(),
+        m_ntt.GetAVX512RootOfUnityPowers().data(),
+        m_ntt.GetAVX512Precon32RootOfUnityPowers().data(), 2, 1);
 
-    for (size_t trial = 0; trial < num_trials; ++trial) {
-      AlignedVector64<uint64_t> input =
-          GenerateInsecureUniformRandomValues(N, 0, modulus);
-      AlignedVector64<uint64_t> input_avx = input;
-      AlignedVector64<uint64_t> input_avx_lazy = input;
-
-      ForwardTransformToBitReverseRadix2(
-          input.data(), N, modulus, ntt.GetRootOfUnityPowers().data(),
-          ntt.GetPrecon64RootOfUnityPowers().data(), 2, 1);
-
-      ForwardTransformToBitReverseAVX512<32>(
-          input_avx.data(), N, ntt.GetModulus(),
-          ntt.GetAVX512RootOfUnityPowers().data(),
-          ntt.GetAVX512Precon32RootOfUnityPowers().data(), 2, 1);
-
-      // Compute lazy
-      ForwardTransformToBitReverseAVX512<32>(
-          input_avx_lazy.data(), N, ntt.GetModulus(),
-          ntt.GetAVX512RootOfUnityPowers().data(),
-          ntt.GetAVX512Precon32RootOfUnityPowers().data(), 2, 4);
-      for (auto& elem : input_avx_lazy) {
-        elem = elem % modulus;
-      }
-
-      ASSERT_EQ(input, input_avx);
-      ASSERT_EQ(input, input_avx_lazy);
+    // Compute lazy
+    ForwardTransformToBitReverseAVX512<32>(
+        input_avx_lazy.data(), m_N, m_ntt.GetModulus(),
+        m_ntt.GetAVX512RootOfUnityPowers().data(),
+        m_ntt.GetAVX512Precon32RootOfUnityPowers().data(), 2, 4);
+    for (auto& elem : input_avx_lazy) {
+      elem = elem % m_modulus;
     }
+
+    ASSERT_EQ(input, input_avx);
+    ASSERT_EQ(input, input_avx_lazy);
   }
 }
 
 // Checks AVX512 and native forward NTT implementations match
-TEST(NTT, FwdNTT_AVX512_64) {
-  if (!has_avx512dq) {
+TEST_P(DegreeModulusBoolTest, FwdNTT_AVX512_64) {
+  if (!has_avx512dq || (m_modulus >= NTT::s_max_fwd_modulus(64))) {
     GTEST_SKIP();
   }
 
-#ifdef HEXL_DEBUG
-  size_t num_trials = 1;
-#else
-  size_t num_trials = 20;
-#endif
+  for (size_t trial = 0; trial < m_num_trials; ++trial) {
+    AlignedVector64<uint64_t> input =
+        GenerateInsecureUniformRandomValues(m_N, 0, m_modulus);
+    AlignedVector64<uint64_t> input_avx = input;
+    AlignedVector64<uint64_t> input_avx_lazy = input;
 
-  for (size_t N = 512; N <= 65536; N *= 2) {
-    uint64_t modulus = GeneratePrimes(1, 55, true, N)[0];
+    ForwardTransformToBitReverseRadix2(
+        input.data(), m_N, m_modulus, m_ntt.GetRootOfUnityPowers().data(),
+        m_ntt.GetPrecon64RootOfUnityPowers().data(), 2, 1);
 
-    NTT ntt(N, modulus);
+    ForwardTransformToBitReverseAVX512<64>(
+        input_avx.data(), m_N, m_ntt.GetModulus(),
+        m_ntt.GetAVX512RootOfUnityPowers().data(),
+        m_ntt.GetAVX512Precon64RootOfUnityPowers().data(), 2, 1);
 
-    for (size_t trial = 0; trial < num_trials; ++trial) {
-      AlignedVector64<uint64_t> input =
-          GenerateInsecureUniformRandomValues(N, 0, modulus);
-      AlignedVector64<uint64_t> input_avx = input;
-      AlignedVector64<uint64_t> input_avx_lazy = input;
-
-      ForwardTransformToBitReverseRadix2(
-          input.data(), N, modulus, ntt.GetRootOfUnityPowers().data(),
-          ntt.GetPrecon64RootOfUnityPowers().data(), 2, 1);
-
-      ForwardTransformToBitReverseAVX512<64>(
-          input_avx.data(), N, ntt.GetModulus(),
-          ntt.GetAVX512RootOfUnityPowers().data(),
-          ntt.GetAVX512Precon64RootOfUnityPowers().data(), 2, 1);
-
-      // Compute lazy
-      ForwardTransformToBitReverseAVX512<64>(
-          input_avx_lazy.data(), N, ntt.GetModulus(),
-          ntt.GetAVX512RootOfUnityPowers().data(),
-          ntt.GetAVX512Precon64RootOfUnityPowers().data(), 2, 4);
-      for (auto& elem : input_avx_lazy) {
-        elem = elem % modulus;
-      }
-
-      ASSERT_EQ(input, input_avx);
-      ASSERT_EQ(input, input_avx_lazy);
+    // Compute lazy
+    ForwardTransformToBitReverseAVX512<64>(
+        input_avx_lazy.data(), m_N, m_ntt.GetModulus(),
+        m_ntt.GetAVX512RootOfUnityPowers().data(),
+        m_ntt.GetAVX512Precon64RootOfUnityPowers().data(), 2, 4);
+    for (auto& elem : input_avx_lazy) {
+      elem = elem % m_modulus;
     }
+
+    ASSERT_EQ(input, input_avx);
+    ASSERT_EQ(input, input_avx_lazy);
   }
 }
 
 // Checks 32-bit AVX512 and native InvNTT implementations match
-TEST(NTT, InvNTT_AVX512_32) {
-  if (!has_avx512dq) {
+TEST_P(DegreeModulusBoolTest, InvNTT_AVX512_32) {
+  if (!has_avx512dq || (m_modulus >= NTT::s_max_inv_modulus(32))) {
     GTEST_SKIP();
   }
 
-#ifdef HEXL_DEBUG
-  size_t num_trials = 1;
-#else
-  size_t num_trials = 20;
-#endif
+  for (size_t trial = 0; trial < m_num_trials; ++trial) {
+    AlignedVector64<uint64_t> input =
+        GenerateInsecureUniformRandomValues(m_N, 0, m_modulus);
 
-  for (size_t N = 512; N <= 65536; N *= 2) {
-    uint64_t modulus = GeneratePrimes(1, 27, true, N)[0];
+    AlignedVector64<uint64_t> input_avx = input;
+    AlignedVector64<uint64_t> input_avx_lazy = input;
 
-    NTT ntt(N, modulus);
+    InverseTransformFromBitReverseRadix2(
+        input.data(), m_N, m_modulus, m_ntt.GetInvRootOfUnityPowers().data(),
+        m_ntt.GetPrecon64InvRootOfUnityPowers().data(), 1, 1);
 
-    for (size_t trial = 0; trial < num_trials; ++trial) {
-      AlignedVector64<uint64_t> input =
-          GenerateInsecureUniformRandomValues(N, 0, modulus);
+    InverseTransformFromBitReverseAVX512<32>(
+        input_avx.data(), m_N, m_ntt.GetModulus(),
+        m_ntt.GetInvRootOfUnityPowers().data(),
+        m_ntt.GetPrecon32InvRootOfUnityPowers().data(), 1, 1);
 
-      AlignedVector64<uint64_t> input_avx = input;
-      AlignedVector64<uint64_t> input_avx_lazy = input;
-
-      InverseTransformFromBitReverseRadix2(
-          input.data(), N, modulus, ntt.GetInvRootOfUnityPowers().data(),
-          ntt.GetPrecon64InvRootOfUnityPowers().data(), 1, 1);
-
-      InverseTransformFromBitReverseAVX512<32>(
-          input_avx.data(), N, ntt.GetModulus(),
-          ntt.GetInvRootOfUnityPowers().data(),
-          ntt.GetPrecon32InvRootOfUnityPowers().data(), 1, 1);
-
-      // Compute lazy
-      InverseTransformFromBitReverseAVX512<32>(
-          input_avx_lazy.data(), N, ntt.GetModulus(),
-          ntt.GetInvRootOfUnityPowers().data(),
-          ntt.GetPrecon32InvRootOfUnityPowers().data(), 1, 2);
-      for (auto& elem : input_avx_lazy) {
-        elem = elem % modulus;
-      }
-
-      ASSERT_EQ(input, input_avx);
-      ASSERT_EQ(input, input_avx_lazy);
+    // Compute lazy
+    InverseTransformFromBitReverseAVX512<32>(
+        input_avx_lazy.data(), m_N, m_ntt.GetModulus(),
+        m_ntt.GetInvRootOfUnityPowers().data(),
+        m_ntt.GetPrecon32InvRootOfUnityPowers().data(), 1, 2);
+    for (auto& elem : input_avx_lazy) {
+      elem = elem % m_modulus;
     }
+
+    ASSERT_EQ(input, input_avx);
+    ASSERT_EQ(input, input_avx_lazy);
   }
 }
 
 // Checks 64-bit AVX512 and native InvNTT implementations match
-TEST(NTT, InvNTT_AVX512_64) {
-  if (!has_avx512dq) {
+TEST_P(DegreeModulusBoolTest, InvNTT_AVX512_64) {
+  if (!has_avx512dq || (m_modulus >= NTT::s_max_inv_modulus(64))) {
     GTEST_SKIP();
   }
 
-#ifdef HEXL_DEBUG
-  size_t num_trials = 1;
-#else
-  size_t num_trials = 20;
-#endif
+  for (size_t trial = 0; trial < m_num_trials; ++trial) {
+    AlignedVector64<uint64_t> input =
+        GenerateInsecureUniformRandomValues(m_N, 0, m_modulus);
+    AlignedVector64<uint64_t> input_avx = input;
+    AlignedVector64<uint64_t> input_avx_lazy = input;
 
-  for (size_t N = 512; N <= 65536; N *= 2) {
-    uint64_t modulus = GeneratePrimes(1, 55, true, N)[0];
+    InverseTransformFromBitReverseRadix2(
+        input.data(), m_N, m_modulus, m_ntt.GetInvRootOfUnityPowers().data(),
+        m_ntt.GetPrecon64InvRootOfUnityPowers().data(), 1, 1);
 
-    NTT ntt(N, modulus);
+    InverseTransformFromBitReverseAVX512<64>(
+        input_avx.data(), m_N, m_ntt.GetModulus(),
+        m_ntt.GetInvRootOfUnityPowers().data(),
+        m_ntt.GetPrecon64InvRootOfUnityPowers().data(), 1, 1);
 
-    for (size_t trial = 0; trial < num_trials; ++trial) {
-      AlignedVector64<uint64_t> input =
-          GenerateInsecureUniformRandomValues(N, 0, modulus);
-      AlignedVector64<uint64_t> input_avx = input;
-      AlignedVector64<uint64_t> input_avx_lazy = input;
-
-      InverseTransformFromBitReverseRadix2(
-          input.data(), N, modulus, ntt.GetInvRootOfUnityPowers().data(),
-          ntt.GetPrecon64InvRootOfUnityPowers().data(), 1, 1);
-
-      InverseTransformFromBitReverseAVX512<64>(
-          input_avx.data(), N, ntt.GetModulus(),
-          ntt.GetInvRootOfUnityPowers().data(),
-          ntt.GetPrecon64InvRootOfUnityPowers().data(), 1, 1);
-
-      // Compute lazy
-      InverseTransformFromBitReverseAVX512<64>(
-          input_avx_lazy.data(), N, ntt.GetModulus(),
-          ntt.GetInvRootOfUnityPowers().data(),
-          ntt.GetPrecon64InvRootOfUnityPowers().data(), 1, 2);
-      for (auto& elem : input_avx_lazy) {
-        elem = elem % modulus;
-      }
-
-      ASSERT_EQ(input, input_avx);
-      ASSERT_EQ(input, input_avx_lazy);
+    // Compute lazy
+    InverseTransformFromBitReverseAVX512<64>(
+        input_avx_lazy.data(), m_N, m_ntt.GetModulus(),
+        m_ntt.GetInvRootOfUnityPowers().data(),
+        m_ntt.GetPrecon64InvRootOfUnityPowers().data(), 1, 2);
+    for (auto& elem : input_avx_lazy) {
+      elem = elem % m_modulus;
     }
+
+    ASSERT_EQ(input, input_avx);
+    ASSERT_EQ(input, input_avx_lazy);
   }
 }
 #endif
+
+INSTANTIATE_TEST_SUITE_P(
+    NTT_AVX512, DegreeModulusBoolTest,
+    ::testing::Combine(::testing::ValuesIn(AlignedVector64<uint64_t>{
+                           1 << 11, 1 << 12, 1 << 13}),
+                       ::testing::ValuesIn(AlignedVector64<uint64_t>{
+                           27, 28, 29, 30, 31, 32, 33, 48, 49, 50, 51, 58, 59,
+                           60}),
+                       ::testing::ValuesIn(std::vector<bool>{false, true})));
 
 }  // namespace hexl
 }  // namespace intel

--- a/test/test-ntt-avx512.cpp
+++ b/test/test-ntt-avx512.cpp
@@ -240,7 +240,7 @@ TEST_P(NttAVX512Test, InvNTT_AVX512IFMA) {
     AssertEqual(input64, input_ifma_lazy);
   }
 }
-#endif
+#endif  // HEXL_HAS_AVX512IFMA
 
 // Checks AVX512 and native forward NTT implementations match
 TEST_P(NttAVX512Test, FwdNTT_AVX512_32) {
@@ -382,7 +382,6 @@ TEST_P(NttAVX512Test, InvNTT_AVX512_64) {
     ASSERT_EQ(input, input_avx_lazy);
   }
 }
-#endif
 
 INSTANTIATE_TEST_SUITE_P(
     NTT, NttAVX512Test,
@@ -392,6 +391,7 @@ INSTANTIATE_TEST_SUITE_P(
                            27, 28, 29, 30, 31, 32, 33, 48, 49, 50, 51, 58, 59,
                            60}),
                        ::testing::ValuesIn(std::vector<bool>{false, true})));
+#endif  // HEXL_HAS_AVX512DQ
 
 }  // namespace hexl
 }  // namespace intel

--- a/test/test-ntt-util.hpp
+++ b/test/test-ntt-util.hpp
@@ -1,0 +1,63 @@
+// Copyright (C) 2020-2021 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+#include "hexl/logging/logging.hpp"
+#include "hexl/util/aligned-allocator.hpp"
+#include "hexl/util/check.hpp"
+#include "hexl/util/compiler.hpp"
+
+namespace intel {
+namespace hexl {
+
+// First parameter is the NTT degree
+// Second parameter is the number of bits in the NTT modulus
+// Third parameter is whether or not to prefer small primes
+class DegreeModulusBoolTest
+    : public ::testing::TestWithParam<std::tuple<uint64_t, uint64_t, bool>> {
+ protected:
+  void SetUp() override {
+    m_N = std::get<0>(GetParam());
+    m_modulus_bits = std::get<1>(GetParam());
+    m_prefer_small_primes = std::get<2>(GetParam());
+    m_modulus =
+        GeneratePrimes(1, m_modulus_bits, m_prefer_small_primes, m_N)[0];
+    m_ntt = NTT(m_N, m_modulus);
+
+#ifdef HEXL_DEBUG
+    m_num_trials = 1;
+#else
+    m_num_trials = 10;
+#endif
+  }
+
+  void TearDown() override {}
+
+ public:
+  uint64_t m_N;
+  uint64_t m_modulus_bits;
+  bool m_prefer_small_primes;
+  uint64_t m_modulus;
+  NTT m_ntt;
+
+  uint64_t m_num_trials;
+};
+
+// Parameters = (degree, modulus, input, expected_output)
+class DegreeModulusInputOutput
+    : public ::testing::TestWithParam<std::tuple<
+          uint64_t, uint64_t, std::vector<uint64_t>, std::vector<uint64_t>>> {
+ protected:
+  void SetUp() {}
+
+  void TearDown() {}
+
+ public:
+};
+
+}  // namespace hexl
+}  // namespace intel

--- a/test/test-ntt.cpp
+++ b/test/test-ntt.cpp
@@ -11,6 +11,7 @@
 #include "hexl/number-theory/number-theory.hpp"
 #include "hexl/util/defines.hpp"
 #include "ntt/ntt-internal.hpp"
+#include "test-ntt-util.hpp"
 #include "test-util.hpp"
 #include "util/cpu-features.hpp"
 
@@ -226,18 +227,6 @@ TEST(NTT, root_of_unity2) {
   EXPECT_EQ(ntt.GetInvRootOfUnityPower(0), ntt.GetInvRootOfUnityPowers()[0]);
 }
 
-// Parameters = (degree, modulus, input, expected_output)
-class DegreeModulusInputOutput
-    : public ::testing::TestWithParam<std::tuple<
-          uint64_t, uint64_t, std::vector<uint64_t>, std::vector<uint64_t>>> {
- protected:
-  void SetUp() {}
-
-  void TearDown() {}
-
- public:
-};
-
 // Test different parts of the public API
 TEST_P(DegreeModulusInputOutput, API) {
   uint64_t N = std::get<0>(GetParam());
@@ -352,98 +341,59 @@ INSTANTIATE_TEST_SUITE_P(
                                   12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
                                   23, 24, 25, 26, 27, 28, 29, 30, 31, 32})));
 
-// First parameter is the NTT degree
-// Second parameter is the number of bits in the NTT modulus
-class DegreeModulusTest
-    : public ::testing::TestWithParam<std::tuple<uint64_t, uint64_t>> {
- protected:
-  void SetUp() {}
-  void TearDown() {}
-
- public:
-};
-
-TEST_P(DegreeModulusTest, ForwardZeros) {
-  uint64_t N = std::get<0>(GetParam());
-  uint64_t modulus_bits = std::get<1>(GetParam());
-  uint64_t modulus = GeneratePrimes(1, modulus_bits, true, N)[0];
-
-  std::vector<uint64_t> input(N, 0);
-  std::vector<uint64_t> exp_output(N, 0);
-
-  NTT ntt(N, modulus);
-  ntt.ComputeForward(input.data(), input.data(), 1, 1);
-
+TEST_P(DegreeModulusBoolTest, ForwardZeros) {
+  std::vector<uint64_t> input(m_N, 0);
+  std::vector<uint64_t> exp_output(m_N, 0);
+  m_ntt.ComputeForward(input.data(), input.data(), 1, 1);
   AssertEqual(input, exp_output);
 }
 
-TEST_P(DegreeModulusTest, InverseZeros) {
-  uint64_t N = std::get<0>(GetParam());
-  uint64_t modulus_bits = std::get<1>(GetParam());
-  uint64_t modulus = GeneratePrimes(1, modulus_bits, true, N)[0];
-
-  std::vector<uint64_t> input(N, 0);
-  std::vector<uint64_t> exp_output(N, 0);
-
-  NTT ntt(N, modulus);
-  ntt.ComputeInverse(input.data(), input.data(), 1, 1);
-
+TEST_P(DegreeModulusBoolTest, InverseZeros) {
+  std::vector<uint64_t> input(m_N, 0);
+  std::vector<uint64_t> exp_output(m_N, 0);
+  m_ntt.ComputeInverse(input.data(), input.data(), 1, 1);
   AssertEqual(input, exp_output);
 }
 
-TEST_P(DegreeModulusTest, ForwardRadix4Random) {
-  uint64_t N = std::get<0>(GetParam());
-  uint64_t modulus_bits = std::get<1>(GetParam());
-  uint64_t modulus = GeneratePrimes(1, modulus_bits, true, N)[0];
-
-  auto input = GenerateInsecureUniformRandomValues(N, 0, modulus);
-
-  NTT ntt(N, modulus);
-
+TEST_P(DegreeModulusBoolTest, ForwardRadix4Random) {
+  auto input = GenerateInsecureUniformRandomValues(m_N, 0, m_modulus);
   auto input_radix4 = input;
-  ForwardTransformToBitReverseRadix4(
-      input_radix4.data(), N, modulus, ntt.GetRootOfUnityPowers().data(),
-      ntt.GetPrecon64RootOfUnityPowers().data(), 2, 1);
 
-  ReferenceForwardTransformToBitReverse(input.data(), N, modulus,
-                                        ntt.GetRootOfUnityPowers().data());
+  ForwardTransformToBitReverseRadix4(
+      input_radix4.data(), m_N, m_modulus, m_ntt.GetRootOfUnityPowers().data(),
+      m_ntt.GetPrecon64RootOfUnityPowers().data(), 2, 1);
+
+  ReferenceForwardTransformToBitReverse(input.data(), m_N, m_modulus,
+                                        m_ntt.GetRootOfUnityPowers().data());
 
   AssertEqual(input, input_radix4);
 }
 
-TEST_P(DegreeModulusTest, InverseRadix4Random) {
-  uint64_t N = std::get<0>(GetParam());
-  uint64_t modulus_bits = std::get<1>(GetParam());
-  uint64_t modulus = GeneratePrimes(1, modulus_bits, true, N)[0];
-
-  auto input = GenerateInsecureUniformRandomValues(N, 0, modulus);
+TEST_P(DegreeModulusBoolTest, InverseRadix4Random) {
+  auto input = GenerateInsecureUniformRandomValues(m_N, 0, m_modulus);
   auto input_radix4 = input;
 
-  NTT ntt(N, modulus);
-
   InverseTransformFromBitReverseRadix2(
-      input.data(), N, modulus, ntt.GetInvRootOfUnityPowers().data(),
-      ntt.GetPrecon64InvRootOfUnityPowers().data(), 2, 1);
+      input.data(), m_N, m_modulus, m_ntt.GetInvRootOfUnityPowers().data(),
+      m_ntt.GetPrecon64InvRootOfUnityPowers().data(), 2, 1);
 
   InverseTransformFromBitReverseRadix4(
-      input_radix4.data(), N, modulus, ntt.GetInvRootOfUnityPowers().data(),
-      ntt.GetPrecon64InvRootOfUnityPowers().data(), 2, 1);
+      input_radix4.data(), m_N, m_modulus,
+      m_ntt.GetInvRootOfUnityPowers().data(),
+      m_ntt.GetPrecon64InvRootOfUnityPowers().data(), 2, 1);
 
   AssertEqual(input, input_radix4);
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    NTT, DegreeModulusTest,
-    ::testing::Values(
-        std::make_tuple(1 << 1, 30), std::make_tuple(1 << 2, 30),
-        std::make_tuple(1 << 3, 30), std::make_tuple(1 << 4, 35),
-        std::make_tuple(1 << 5, 35), std::make_tuple(1 << 6, 35),
-        std::make_tuple(1 << 7, 40), std::make_tuple(1 << 8, 40),
-        std::make_tuple(1 << 9, 40), std::make_tuple(1 << 10, 45),
-        std::make_tuple(1 << 11, 45), std::make_tuple(1 << 12, 45),
-        std::make_tuple(1 << 13, 50), std::make_tuple(1 << 14, 50),
-        std::make_tuple(1 << 15, 50), std::make_tuple(1 << 16, 55),
-        std::make_tuple(1 << 17, 55)));
+    NTT, DegreeModulusBoolTest,
+    ::testing::Combine(::testing::ValuesIn(AlignedVector64<uint64_t>{
+                           1 << 4, 1 << 5, 1 << 6, 1 << 7, 1 << 8, 1 << 9,
+                           1 << 10, 1 << 11, 1 << 12, 1 << 13}),
+                       ::testing::ValuesIn(AlignedVector64<uint64_t>{
+                           27, 28, 29, 30, 31, 32, 33, 48, 49, 50, 51, 58, 59,
+                           60}),
+                       ::testing::ValuesIn(std::vector<bool>{false, true})));
 
 }  // namespace hexl
 }  // namespace intel

--- a/test/test-ntt.cpp
+++ b/test/test-ntt.cpp
@@ -341,21 +341,23 @@ INSTANTIATE_TEST_SUITE_P(
                                   12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
                                   23, 24, 25, 26, 27, 28, 29, 30, 31, 32})));
 
-TEST_P(DegreeModulusBoolTest, ForwardZeros) {
+class NttNativeTest : public DegreeModulusBoolTest {};
+
+TEST_P(NttNativeTest, ForwardZeros) {
   std::vector<uint64_t> input(m_N, 0);
   std::vector<uint64_t> exp_output(m_N, 0);
   m_ntt.ComputeForward(input.data(), input.data(), 1, 1);
   AssertEqual(input, exp_output);
 }
 
-TEST_P(DegreeModulusBoolTest, InverseZeros) {
+TEST_P(NttNativeTest, InverseZeros) {
   std::vector<uint64_t> input(m_N, 0);
   std::vector<uint64_t> exp_output(m_N, 0);
   m_ntt.ComputeInverse(input.data(), input.data(), 1, 1);
   AssertEqual(input, exp_output);
 }
 
-TEST_P(DegreeModulusBoolTest, ForwardRadix4Random) {
+TEST_P(NttNativeTest, ForwardRadix4Random) {
   auto input = GenerateInsecureUniformRandomValues(m_N, 0, m_modulus);
   auto input_radix4 = input;
 
@@ -369,7 +371,7 @@ TEST_P(DegreeModulusBoolTest, ForwardRadix4Random) {
   AssertEqual(input, input_radix4);
 }
 
-TEST_P(DegreeModulusBoolTest, InverseRadix4Random) {
+TEST_P(NttNativeTest, InverseRadix4Random) {
   auto input = GenerateInsecureUniformRandomValues(m_N, 0, m_modulus);
   auto input_radix4 = input;
 
@@ -386,14 +388,14 @@ TEST_P(DegreeModulusBoolTest, InverseRadix4Random) {
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    NTT, DegreeModulusBoolTest,
-    ::testing::Combine(::testing::ValuesIn(AlignedVector64<uint64_t>{
-                           1 << 4, 1 << 5, 1 << 6, 1 << 7, 1 << 8, 1 << 9,
-                           1 << 10, 1 << 11, 1 << 12, 1 << 13}),
-                       ::testing::ValuesIn(AlignedVector64<uint64_t>{
-                           27, 28, 29, 30, 31, 32, 33, 48, 49, 50, 51, 58, 59,
-                           60}),
-                       ::testing::ValuesIn(std::vector<bool>{false, true})));
+    NTT, NttNativeTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(AlignedVector64<uint64_t>{
+            1 << 1, 1 << 2, 1 << 3, 1 << 4, 1 << 5, 1 << 6, 1 << 7, 1 << 8,
+            1 << 9, 1 << 10, 1 << 11, 1 << 12, 1 << 13}),
+        ::testing::ValuesIn(AlignedVector64<uint64_t>{
+            27, 28, 29, 30, 31, 32, 33, 48, 49, 50, 51, 58, 59, 60}),
+        ::testing::ValuesIn(std::vector<bool>{false, true})));
 
 }  // namespace hexl
 }  // namespace intel


### PR DESCRIPTION
Fix AVX512 NTT on moduli in the range [2^30, 2^31] (see https://jiratest.idoc.intel.com/browse/GLADE-147). Previously, these moduli values mapped to the 32-bit AVX512DQ NTT implementation. However, to prevent overflow, the 32-bit AVX512DQ NTT implementation should only be used for moduli < 2^30.

I've also added a wider coverage on the NTT unit-tests around 28-32 bits to prevent regression in the future.