### PR TITLE
change gbenchmark tag

### DIFF
--- a/cmake/third-party/gbenchmark/CMakeLists.txt.in
+++ b/cmake/third-party/gbenchmark/CMakeLists.txt.in
@@ -8,7 +8,7 @@ project(google-benchmark-download NONE)
 include(ExternalProject)
 ExternalProject_Add(gbenchmark
   GIT_REPOSITORY    https://github.com/google/benchmark.git
-  GIT_TAG           f730846b0a3c0dc0699978846fb14ffb2fad0bdc
+  GIT_TAG           f730846b0a3c0dc0699978846fb14ffb2fad0bdc # main branch on Oct 18, 2021
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/gbenchmark-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/gbenchmark-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
The last commit on https://github.com/google/benchmark triggers a warning which is treated as an error on coverage build. Reverting one commit back. 