### PR TITLE
Add self-hosted Ubuntu-18.04 CI

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -99,7 +99,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        os: [ice-lake, macos-latest, ubuntu-20.04]
+        os: [ice-lake, {self-hosted, ubuntu-18.04}, macos-latest, ubuntu-20.04]
         build_type: [Release, Debug]
         shared_lib: [ON, OFF]
         include:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -24,7 +24,7 @@ on:
 # Define env vars #
 ###################
 env:
-  HEXL_VER: 1.2.3
+  HEXL_VER: 1.2.2
   HEXL_DIR: ${GITHUB_WORKSPACE}/lib/cmake/hexl-${HEXL_VER}
   HEXL_HINT_DIR: >
       -DHEXL_HINT_DIR=${GITHUB_WORKSPACE}/lib/cmake/hexl-${HEXL_VER}

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -180,40 +180,40 @@ jobs:
           path: ${{ github.workspace }}/${{ github.workflow }}_${{ github.sha }}
           retention-days: 90 # Maximum for free version
 
-  # windows-build:
-  #   name: 'Windows ${{ matrix.os }} ${{ matrix.build_type }} shared=${{ matrix.shared_lib }}'
-  #   runs-on: windows-latest
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #   strategy:
-  #     matrix:
-  #       build_type: [Release, Debug]
-  #       # Shared lib in Windows requires exporting symbols
-  #       shared_lib: [OFF]
+  windows-build:
+    name: 'Windows ${{ matrix.os }} ${{ matrix.build_type }} shared=${{ matrix.shared_lib }}'
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        build_type: [Release, Debug]
+        # Shared lib in Windows requires exporting symbols
+        shared_lib: [OFF]
 
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Default build
-  #       run: |
-  #         set -x
-  #         # Build library
-  #         cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type}} \
-  #           -DCMAKE_INSTALL_PREFIX=./ \
-  #           -DHEXL_SHARED_LIB=${{ matrix.shared_lib }}
-  #         cmake --build build -j --config ${{ matrix.build_type}}
-  #         cmake --build build --target install --config ${{ matrix.build_type}}
-  #         cmake --build build --target unittest --config ${{ matrix.build_type}}
-  #         cmake --build build --target bench --config ${{ matrix.build_type}}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Default build
+        run: |
+          set -x
+          # Build library
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type}} \
+            -DCMAKE_INSTALL_PREFIX=./ \
+            -DHEXL_SHARED_LIB=${{ matrix.shared_lib }}
+          cmake --build build -j --config ${{ matrix.build_type}}
+          cmake --build build --target install --config ${{ matrix.build_type}}
+          cmake --build build --target unittest --config ${{ matrix.build_type}}
+          cmake --build build --target bench --config ${{ matrix.build_type}}
 
-  #         # Build and run examples
-  #         cd example/cmake
-  #         cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type}} \
-  #           ${{ env.HEXL_HINT_DIR }}
-  #         cmake --build build --config ${{ matrix.build_type}}
-  #         build/${{ matrix.build_type}}/example.exe
+          # Build and run examples
+          cd example/cmake
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type}} \
+            ${{ env.HEXL_HINT_DIR }}
+          cmake --build build --config ${{ matrix.build_type}}
+          build/${{ matrix.build_type}}/example.exe
 
-  #         # TODO: add pkgconfig and vcpkg examples
+          # TODO: add pkgconfig and vcpkg examples
 
   experimental-build:
     name: 'experimental: ${{ matrix.os }} ${{ matrix.build_type }} shared=${{ matrix.shared_lib }}'

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -24,7 +24,7 @@ on:
 # Define env vars #
 ###################
 env:
-  HEXL_VER: 1.2.2
+  HEXL_VER: 1.2.3
   HEXL_DIR: ${GITHUB_WORKSPACE}/lib/cmake/hexl-${HEXL_VER}
   HEXL_HINT_DIR: >
       -DHEXL_HINT_DIR=${GITHUB_WORKSPACE}/lib/cmake/hexl-${HEXL_VER}
@@ -99,8 +99,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        # TODO: add Linux/ice-lake tag to self-hosted runner
-        os: [self-hosted, macos-latest, ubuntu-20.04]
+        os: [ice-lake, macos-latest, ubuntu-20.04]
         build_type: [Release, Debug]
         shared_lib: [ON, OFF]
         include:
@@ -224,8 +223,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        # TODO: add Linux/ice-lake tag to self-hosted runner
-        os: [self-hosted]
+        os: [ice-lake]
         build_type: [Release]
         shared_lib: [ON]
     steps:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -99,7 +99,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        os: [ice-lake, {self-hosted, ubuntu-18.04}, macos-latest, ubuntu-20.04]
+        os: [ice-lake, [self-hosted, ubuntu-18.04], macos-latest, ubuntu-20.04]
         build_type: [Release, Debug]
         shared_lib: [ON, OFF]
         include:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -180,40 +180,40 @@ jobs:
           path: ${{ github.workspace }}/${{ github.workflow }}_${{ github.sha }}
           retention-days: 90 # Maximum for free version
 
-  windows-build:
-    name: 'Windows ${{ matrix.os }} ${{ matrix.build_type }} shared=${{ matrix.shared_lib }}'
-    runs-on: windows-latest
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      matrix:
-        build_type: [Release, Debug]
-        # Shared lib in Windows requires exporting symbols
-        shared_lib: [OFF]
+  # windows-build:
+  #   name: 'Windows ${{ matrix.os }} ${{ matrix.build_type }} shared=${{ matrix.shared_lib }}'
+  #   runs-on: windows-latest
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   strategy:
+  #     matrix:
+  #       build_type: [Release, Debug]
+  #       # Shared lib in Windows requires exporting symbols
+  #       shared_lib: [OFF]
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Default build
-        run: |
-          set -x
-          # Build library
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type}} \
-            -DCMAKE_INSTALL_PREFIX=./ \
-            -DHEXL_SHARED_LIB=${{ matrix.shared_lib }}
-          cmake --build build -j --config ${{ matrix.build_type}}
-          cmake --build build --target install --config ${{ matrix.build_type}}
-          cmake --build build --target unittest --config ${{ matrix.build_type}}
-          cmake --build build --target bench --config ${{ matrix.build_type}}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Default build
+  #       run: |
+  #         set -x
+  #         # Build library
+  #         cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type}} \
+  #           -DCMAKE_INSTALL_PREFIX=./ \
+  #           -DHEXL_SHARED_LIB=${{ matrix.shared_lib }}
+  #         cmake --build build -j --config ${{ matrix.build_type}}
+  #         cmake --build build --target install --config ${{ matrix.build_type}}
+  #         cmake --build build --target unittest --config ${{ matrix.build_type}}
+  #         cmake --build build --target bench --config ${{ matrix.build_type}}
 
-          # Build and run examples
-          cd example/cmake
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type}} \
-            ${{ env.HEXL_HINT_DIR }}
-          cmake --build build --config ${{ matrix.build_type}}
-          build/${{ matrix.build_type}}/example.exe
+  #         # Build and run examples
+  #         cd example/cmake
+  #         cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type}} \
+  #           ${{ env.HEXL_HINT_DIR }}
+  #         cmake --build build --config ${{ matrix.build_type}}
+  #         build/${{ matrix.build_type}}/example.exe
 
-          # TODO: add pkgconfig and vcpkg examples
+  #         # TODO: add pkgconfig and vcpkg examples
 
   experimental-build:
     name: 'experimental: ${{ matrix.os }} ${{ matrix.build_type }} shared=${{ matrix.shared_lib }}'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # target_link_options and cmake -S . -B build require cmake 3.13
 cmake_minimum_required(VERSION 3.13)
-project(HEXL VERSION 1.2.2 LANGUAGES C CXX)
+project(HEXL VERSION 1.2.3 LANGUAGES C CXX)
 
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # target_link_options and cmake -S . -B build require cmake 3.13
 cmake_minimum_required(VERSION 3.13)
-project(HEXL VERSION 1.2.3 LANGUAGES C CXX)
+project(HEXL VERSION 1.2.2 LANGUAGES C CXX)
 
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)


### PR DESCRIPTION
Added CI to run on a self-hosted Ubuntu 18.04 system. The Windows build still fails because MSVC doesn't support std::__gcd until C++17. Please refer to this [PR ](https://github.com/intel/hexl/pull/94) for more information. 