### PR TITLE
specify hexl version using vcpkg

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,8 +1,8 @@
-# Example using Intel HEXL in an external application
+# Example using Intel HE Acceleration Library in an external application
 
-To use Intel HEXL in an external application, you can use one of the three provided ways.
+To use Intel HE Acceleration Library in an external application, you can use one of the three provided ways.
 
-* Install Intel HEXL. Then, in your external application, add the following lines to your `CMakeLists.txt`:
+* Install Intel HE Acceleration Library. Then, in your external application, add the following lines to your `CMakeLists.txt`:
 
 ```bash
 find_package(HEXL 1.2.2
@@ -10,9 +10,9 @@ find_package(HEXL 1.2.2
     REQUIRED)
 target_link_libraries(<your target> HEXL::hexl)
 ```
-If Intel HEXL is installed globally, `HEXL_HINT_DIR` is not needed. Otherwise, `HEXL_HINT_DIR` should be the directory containing  `HEXLConfig.cmake`, e.g. `${CMAKE_INSTALL_PREFIX}/lib/cmake/hexl-1.2.2/`
+If Intel HE Acceleration Library is installed globally, `HEXL_HINT_DIR` is not needed. Otherwise, `HEXL_HINT_DIR` should be the directory containing  `HEXLConfig.cmake`, e.g. `${CMAKE_INSTALL_PREFIX}/lib/cmake/hexl-1.2.2/`
 
-* Install Intel HEXL. Then, in your external application, add the following lines to your `CMakeLists.txt`:
+* Install Intel HE Acceleration Library. Then, in your external application, add the following lines to your `CMakeLists.txt`:
 
 ```bash
 include(FindPkgConfig)
@@ -20,9 +20,11 @@ pkg_check_modules(HEXL REQUIRED IMPORTED_TARGET hexl)
 target_link_libraries(<your target> PkgConfig::HEXL)
 ```
 
-* Install Intel HEXL from vcpkg. Then, in your external application, add the following lines to your `CMakeLists.txt`:
+* Install Intel HE Acceleration Library from vcpkg. Then, in your external application, add the following lines to your `CMakeLists.txt`:
 
 ```bash
 find_package(HEXL CONFIG REQUIRED)
 target_link_libraries(<your target> HEXL::hexl)
 ```
+
+To install a specific version of Intel HE Acceleration Library using vcpkg, use package versioning feature provided by vcpkg. An example manifest file is provided at `/path/to/hexl/example/vcpkg/vcpkg.json` with baseline pointing to a specific vcpkg commit. While building, overrides  will  force vcpkg to install and use the exact version specified.

--- a/example/vcpkg/vcpkg.json
+++ b/example/vcpkg/vcpkg.json
@@ -1,0 +1,14 @@
+{
+    "name": "hexl-example",
+    "version": "1.0.0",
+    "dependencies": [
+        {
+            "name": "hexl",
+            "version>=": "1.2.3"
+        }
+    ],
+    "builtin-baseline": "7baf7bc9f3390bab2f47e2bcbd35b065663bc80d",
+    "overrides": [
+        { "name": "hexl", "version": "1.2.1", "port-version": 0}
+    ]
+}


### PR DESCRIPTION
replace HEXL with Intel HE Acceleration Library, add example on how to use previous version with vcpkg
Closes https://jira.idoc.intel.com/browse/GLADE-236 