### PR TITLE
Point to "main" instead of "master"

### DIFF
--- a/cmake/third-party/cpu-features/CMakeLists.txt.in
+++ b/cmake/third-party/cpu-features/CMakeLists.txt.in
@@ -8,7 +8,7 @@ project(cpu-features-download NONE)
 include(ExternalProject)
 ExternalProject_Add(cpu_features
   GIT_REPOSITORY    https://github.com/google/cpu_features.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/cpu-features-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/cpu-features-build"
   CONFIGURE_COMMAND ""

--- a/cmake/third-party/easylogging/CMakeLists.txt.in
+++ b/cmake/third-party/easylogging/CMakeLists.txt.in
@@ -8,7 +8,7 @@ project(easylogging-download NONE)
 include(ExternalProject)
 ExternalProject_Add(easylogging
   GIT_REPOSITORY    https://github.com/amrayn/easyloggingpp.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/easylogging-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/easylogging-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
Version 1.2.1 should also Fix Google benchmark branch to point to "main" instead of "master"
